### PR TITLE
Output semantic HTML

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11,6 +11,7 @@ import ombpdf.underlines
 import ombpdf.html
 import ombpdf.pagenumbers
 import ombpdf.headings
+import ombpdf.semhtml
 
 
 def get_doc(filename):
@@ -81,6 +82,15 @@ def html(filename):
     "Convert the given PDF to HTML."
 
     content = ombpdf.html.to_html(get_doc(filename)).encode('utf-8')
+    sys.stdout.buffer.write(content)
+
+
+@cli.command()
+@click.argument('filename')
+def semhtml(filename):
+    "Convert the given PDF to semantic HTML."
+
+    content = ombpdf.semhtml.to_html(get_doc(filename)).encode('utf-8')
     sys.stdout.buffer.write(content)
 
 

--- a/ombpdf/semhtml.py
+++ b/ombpdf/semhtml.py
@@ -1,0 +1,115 @@
+from html import escape
+
+from . import document
+
+
+HTML_INTRO = """\
+<!DOCTYPE html>
+<meta charset="utf-8">
+"""
+
+
+def to_html(doc):
+    doc.annotators.require_all()
+    chunks = [
+        f'<title>Semantic HTML output for {doc.filename}</title>\n'
+    ]
+
+    footnotes = []
+    block_stack = []
+
+    def open_new_block(tagname, anno):
+        block_stack.append((tagname, anno))
+        chunks.append(f'<{tagname}>')
+
+    def close_current_block():
+        if block_stack:
+            tagname, _ = block_stack.pop()
+            chunks.append(f'</{tagname}>\n')
+
+    def does_current_block_match(anno=None, tagnames=None):
+        if not block_stack:
+            return False
+        curr_tagname, curr_anno = block_stack[-1]
+        if anno is not None:
+            return (anno.__class__ == curr_anno.__class__ and
+                    anno == curr_anno)
+        return curr_tagname in tagnames
+
+    def close_all_blocks():
+        while block_stack:
+            close_current_block()
+
+    def create_new_list(anno):
+        if anno.is_ordered:
+            open_new_block('ol', anno)
+        else:
+            open_new_block('ul', anno)
+
+    def process_new_list_item(anno):
+        if does_current_block_match(tagnames=['li']):
+            _, prev_anno = block_stack[-1]
+            if prev_anno.list_id == anno.list_id:
+                # It's another item in the same list.
+                close_current_block()
+                open_new_block('li', anno)
+            elif prev_anno.indentation < anno.indentation:
+                # It's a new nested list, inside a parent list.
+                create_new_list(anno)
+                open_new_block('li', anno)
+            else:
+                # A nested list has finished and we're back in
+                # the parent list.
+                close_current_block()  # Close final nested <li>
+                close_current_block()  # Close nested list
+                close_current_block()  # Close parent <li>
+                open_new_block('li', anno)
+        else:
+            # It's a new list following non-list content.
+            close_all_blocks()
+            create_new_list(anno)
+            open_new_block('li', anno)
+
+    def process_line(line):
+        for char, text in line.iter_char_chunks():
+            anno = char.annotation
+
+            if isinstance(anno, document.OMBListItemMarker):
+                # Don't display this content at all.
+                pass
+            elif isinstance(anno, document.OMBFootnoteCitation):
+                # TODO: Add link to footnote.
+                chunks.append(
+                    f'<sup>{anno.number}</sup>'
+                )
+            else:
+                chunks.append(escape(text))
+
+    for line in doc.lines:
+        anno = line.annotation
+        ignore_line = False
+        if anno and does_current_block_match(anno=anno):
+            pass
+        else:
+            if isinstance(anno, document.OMBFootnote):
+                footnotes.append(line)
+                ignore_line = True
+            elif isinstance(anno, document.OMBPageNumber):
+                ignore_line = True
+            elif isinstance(anno, document.OMBParagraph):
+                close_all_blocks()
+                open_new_block('p', anno)
+            elif isinstance(anno, document.OMBListItem):
+                process_new_list_item(anno)
+            elif isinstance(anno, document.OMBHeading):
+                close_all_blocks()
+                open_new_block(f'h{anno.level}', anno)
+
+        if not ignore_line:
+            process_line(line)
+
+    close_all_blocks()
+
+    # TODO: Add footnotes.
+
+    return ''.join(chunks)

--- a/tests/test_semhtml.py
+++ b/tests/test_semhtml.py
@@ -1,0 +1,34 @@
+import re
+from pathlib import Path
+import difflib
+
+from ombpdf.semhtml import to_html
+
+
+MY_DIR = Path(__file__).parent
+
+
+def test_to_html_works(m_16_19_doc):
+    html = to_html(m_16_19_doc)
+
+    expected_html_path = MY_DIR / 'test_semhtml.snapshot.html'
+    expected_html_path = expected_html_path.relative_to(Path('.').resolve())
+
+    if not expected_html_path.exists():
+        expected_html_path.write_text(html, encoding='utf-8')
+
+    expected_html = expected_html_path.read_text(encoding='utf-8')
+
+    if expected_html != html:
+        print('\n'.join(difflib.unified_diff(
+            expected_html.splitlines(),
+            html.splitlines(),
+            tofile=f'Current HTML output',
+            fromfile=str(expected_html_path),
+        )))
+        raise AssertionError(
+            'Current HTML output does not match snapshot. If '
+            'you want to bless the current output as the new snapshot, '
+            f'please delete {expected_html_path} and re-run this test.'
+            "You'll also want to commit the updated snapshot to git."
+        )

--- a/tests/test_semhtml.snapshot.html
+++ b/tests/test_semhtml.snapshot.html
@@ -1,0 +1,660 @@
+<title>Semantic HTML output for m_16_19_1.pdf</title>
+ 
+ 
+ 
+ 
+August 1, 2016 
+ 
+<h3>M-16-19 
+ 
+MEMORANDUM FOR HEADS OF EXECUTIVE DEPARTMENTS AND AGENCIES 
+ 
+FROM: 
+Tony Scott 
+Federal Chief Information Officer  
+ 
+SUBJECT:  Data Center Optimization Initiative (DCOI) 
+ 
+ 
+</h3>
+<h1>Background 
+ 
+</h1>
+<p>In 2010, the Office of Management and Budget (OMB) launched the Federal Data Center 
+Consolidation Initiative (FDCCI) to promote the use of green IT by reducing the overall energy 
+and real estate footprint of government data centers; reduce the cost of data center hardware, 
+software, and operations; increase the overall IT security posture of the Federal Government; and 
+shift IT investments to more efficient computing platforms and technologies.<sup id="footnote-citation-1"><a href="#footnote-1">1</a></sup> 
+ 
+</p>
+<p>In December 2014, the President signed into law the Federal Information Technology 
+Acquisition Reform Act (FITARA),<sup id="footnote-citation-2"><a href="#footnote-2">2</a></sup> which enacts and builds upon the requirements of the 
+FDCCI.  FITARA requires that agencies submit annual reports that are to include: 
+comprehensive data center inventories, multi-year strategies to consolidate and optimize data 
+centers, performance metrics and a timeline for agency activities, and yearly calculations of 
+investment and cost savings. 
+ 
+</p>
+<p>In addition, FITARA requires the Administrator of the Office of E-Government and Information 
+Technology (henceforth referred to as the Office of the Federal Chief Information Officer 
+(OFCIO)<sup id="footnote-citation-3"><a href="#footnote-3">3</a></sup>) to establish and publish cost savings and optimization improvements, provide public 
+updates on cumulative cost savings and optimization improvements, and review agencies’ data 
+center inventories and the implementation of data center management strategies. 
+ 
+ 
+                                                        
+</p>
+<p>This memorandum defines a framework for achieving the data center consolidation and 
+optimization requirements of FITARA, the criteria for successful agency data center strategies, 
+and the metrics OMB OFCIO will use to evaluate the success of those strategies. 
+ 
+</p>
+<h1>Policy 
+ 
+</h1>
+<p>As of August 1, 2016, the FDCCI is superseded by the Data Center Optimization Initiative 
+(DCOI) established in this memorandum. 
+ 
+</p>
+<p>The DCOI, as described in this memorandum, requires agencies to develop and report on data 
+center strategies to consolidate inefficient infrastructure, optimize existing facilities, improve 
+security posture, achieve cost savings, and transition to more efficient infrastructure, such as 
+cloud services and inter-agency shared services.<sup id="footnote-citation-4"><a href="#footnote-4">4</a></sup> 
+ 
+</p>
+<p>The requirements in this memorandum apply to all CFO Act agencies,<sup id="footnote-citation-5"><a href="#footnote-5">5</a></sup> including the Department 
+of Defense.<sup id="footnote-citation-6"><a href="#footnote-6">6</a></sup> 
+ 
+</p>
+<h2>Leadership and Responsibilities 
+ 
+</h2>
+<p>All data center infrastructure and services, including contracts for third-party data centers and 
+services agency-wide, shall be managed by the agency CIO in a manner consistent with 
+FITARA<sup id="footnote-citation-7"><a href="#footnote-7">7</a></sup> and OMB Memorandum M-15-14, “Management and Oversight of Information 
+Technology.”<sup id="footnote-citation-8"><a href="#footnote-8">8</a></sup> The agency CIO shall be responsible for implementing and measuring progress 
+toward meeting the goals set forth in this memorandum. 
+ 
+</p>
+<h2>Transition to Cloud and Data Center Shared Services 
+ 
+</h2>
+<h3>Development Freeze for New and Current Data Centers 
+ 
+</h3>
+<p>Beginning 180 days after issuance of this memorandum, agencies may not budget any funds or 
+resources toward initiating a new data center or significantly expanding<sup id="footnote-citation-9"><a href="#footnote-9">9</a></sup> an existing data center 
+                                                        
+ 
+without approval from OMB OFCIO.<sup id="footnote-citation-10"><a href="#footnote-10">10</a></sup> To request such approval, agencies must submit a written 
+justification that includes an analysis of alternatives (including opportunities for cloud services, 
+inter-agency shared services, and third party co-location) and an explanation of the net reduction 
+in the agency’s data center inventory that will be facilitated by the new or expanded data center 
+(such as through consolidation of multiple existing data centers into a single new data center). 
+ 
+</p>
+<h3>Consolidation and Closure of Existing Data Centers 
+ 
+</h3>
+<p>As previously required by the FDCCI, agencies shall continue to principally reduce application, 
+system, and database inventories to essential enterprise levels by increasing the use of 
+virtualization to enable pooling of storage, network and computer resources, and dynamic 
+allocation on-demand.  Thereafter, agencies shall evaluate options for the consolidation and 
+closure of existing data centers,<sup id="footnote-citation-11"><a href="#footnote-11">11</a></sup> by (in order of priority): 
+ 
+</p>
+<ol><li>Transitioning to provisioned services, including configurable and flexible technology 
+such as Software as a Service (SaaS), Platform as a Service (PaaS), and Infrastructure as 
+a Service (IaaS) to the furthest extent practicable, consistent with the Cloud First 
+policy.<sup id="footnote-citation-12"><a href="#footnote-12">12</a></sup> 
+</li>
+<li>Migrating to inter-agency shared services or co-location data centers. 
+</li>
+<li>Migrating to more optimized data centers within the agency’s data center inventory. 
+ 
+</li>
+</ol>
+<h3>Cloud Investment 
+ 
+</h3>
+<p>Cloud environments are scalable and allow agencies to provision resources as required, on-
+demand.<sup id="footnote-citation-13"><a href="#footnote-13">13</a></sup> Consistent with the Cloud First policy, agencies shall use cloud infrastructure where 
+possible when planning new mission or support applications or consolidating existing 
+applications. Agencies should take into consideration cost, security requirements, and application 
+needs when evaluating cloud environments. As required by FITARA, agencies utilizing cloud 
+services shall do so in a manner that is consistent with requirements of the Federal Risk and 
+Authorization Management Program (FedRAMP) and National Institute of Standards and 
+Technology (NIST) guidance.<sup id="footnote-citation-14"><a href="#footnote-14">14</a></sup> 
+ 
+</p>
+<h3>Shared Services Managing Partner 
+ 
+</h3>
+<p>To support the shared services efforts described by this memorandum, the General Services 
+Administration (GSA) Office of Government-wide Policy (OGP) shall serve as the managing 
+                                                        
+ 
+partner of the Federal Government’s data center line of business<sup id="footnote-citation-15"><a href="#footnote-15">15</a></sup> and data center shared 
+services. OGP, in consultation with the Unified Shared Services Management office, shall 
+establish and maintain a data center shared services marketplace and coordinate shared services 
+for inter-agency consumption by: 
+ 
+</p>
+<ul><li>Coordinating with OMB to define qualifying operating standards for inter-agency shared 
+services providers, creating guidance materials for becoming such a provider, and 
+identifying and approving candidate providers. 
+</li>
+<li>Maintaining and monitoring inter-agency shared services provider operating standards. 
+</li>
+<li>Maintaining an online inventory of qualified inter-agency shared services providers. 
+</li>
+<li>Establishing an online decision support tool to facilitate agency review, selection, and 
+analysis of inter-agency shared services providers. 
+</li>
+<li>Coordinating with the GSA Federal Acquisition Service (FAS) to create and maintain an 
+inventory of acquisition tools and products specific to the technology and services 
+surrounding data center optimization, including procurement vehicles for the acquisition 
+of automated infrastructure management and monitoring tools. 
+</li>
+<li>Developing, implementing, and maintaining financial and service models, as well as 
+contracts, pertaining to data center procurement with customer/partner agencies and 
+shared service providers.  
+</li>
+<li>Providing a forum for participating and interested agencies to discuss the inter-agency 
+shared services marketplace. 
+4 
+ 
+</li>
+</ul>
+<p>In this role, OGP will serve as a trusted agent and subject matter expert to assist data center 
+providers and consumers of data center services by providing guidance on technology 
+advancements, innovation, cybersecurity, and best practices. 
+ 
+</p>
+<p>All agencies will have the option of submitting data centers of their choosing for review by OGP. 
+Data centers that OGP determines satisfactory in all of their operating standards will be 
+designated as inter-agency shared services providers.  
+ 
+</p>
+<h2>Optimization of Physical Data Centers 
+ 
+</h2>
+<h3>Classification of Physical Data Centers 
+ 
+</h3>
+<p>For the purposes of this memorandum, rooms with at least one server, providing services 
+(whether in a production, test, staging, development, or any other environment) are considered 
+data centers. However, rooms containing only print servers, routing equipment, switches, 
+security devices (such as firewalls), or other telecommunications components shall not be 
+                                                        
+ 
+considered data centers. Agencies shall perform a comprehensive review of their data center 
+inventories and continue to maintain complete and updated data center inventories. This 
+comprehensive review shall be completed by August 31, 2016, to align with the Integrated Data 
+Collection (IDC) process.<sup id="footnote-citation-16"><a href="#footnote-16">16</a></sup> 
+ 
+</p>
+<p>Data centers shall be categorized into two groups: tiered<sup id="footnote-citation-17"><a href="#footnote-17">17</a></sup> data centers and non-tiered data 
+centers.  Tiered data centers are defined as those that utilize each of the following: 1) a separate 
+physical space for IT infrastructure; 2) an uninterruptible power supply; 3) a dedicated cooling 
+system or zone; and 4) a backup power generator for prolonged power outages. All other data 
+centers shall be considered non-tiered data centers.<sup id="footnote-citation-18"><a href="#footnote-18">18</a></sup> Private sector-provided cloud services are 
+not considered data centers for the purposes of this memorandum, but must continue to be 
+included in agencies’ quarterly inventory data submissions to OMB. 
+ 
+</p>
+<p>Agencies shall self-classify data centers as either tiered or non-tiered data centers based on the 
+above criteria; however, any data center previously reported to OMB as a Tier 1-4 data center 
+shall be automatically categorized as a tiered data center. 
+ 
+</p>
+<p>Under this memorandum, OMB sets closure and optimization targets that are applicable to each 
+type of data center. Additionally, the terms “core” and “non-core” will no longer be used as the 
+categorical benchmarks for OMB oversight. 
+ 
+</p>
+<h3>Energy Metering and Power Efficiency 
+ 
+</h3>
+<p>Agencies shall install automated energy metering tools and shall use these to collect and report 
+energy usage data in their data centers to OMB. The March 19, 2015, Executive Order 13693, 
+“Planning for Federal Sustainability in the Next Decade,” requires agencies to install and 
+monitor advanced energy meters in data centers by September 30, 2018.<sup id="footnote-citation-19"><a href="#footnote-19">19</a></sup>  
+ 
+</p>
+<p>Consistent with the Implementing Instructions for Executive Order 13693 (E.O. Implementing 
+Instructions), energy metering tools shall enable the active tracking of PUE for the data center 
+and shall be installed in all tiered Federal data centers by September 30, 2018.<sup id="footnote-citation-20"><a href="#footnote-20">20</a></sup> The E.O. 
+                                                        
+ 
+</p>
+<p>Implementing Instructions also advise that “[a]ll existing and new data centers shall have at least 
+one certified Data Center Energy Practitioner (DCEP) assigned to manage its performance.”<sup id="footnote-citation-21"><a href="#footnote-21">21</a></sup>  
+ 
+</p>
+<p>Consistent with the E.O. Implementing Instructions, agency CIOs are also required under this 
+memorandum to ensure that existing tiered data centers achieve and maintain a PUE of less than 
+1.5 by September 30, 2018.  Agency CIOs shall evaluate options for consolidation or closure of 
+existing data centers in which a PUE target of less than 1.5 is not cost-effective, such as through 
+transition to cloud services or migration to inter-agency shared services data centers. 
+ 
+</p>
+<p>Accordingly, OMB will monitor the energy efficiency of data center power and cooling 
+infrastructure through the Power Usage Effectiveness (PUE) metric. Consistent with the E.O. 
+Implementing Instructions, effective immediately, all new data centers must implement energy 
+metering capable of measuring PUE and must be designed and operated to maintain a PUE no 
+greater than 1.4, and are encouraged to be designed and operated to achieve a PUE no greater 
+than 1.2.  
+ 
+</p>
+<p>To the extent permissible under the Federal Acquisition Regulation (FAR), agencies must 
+include PUE requirements for all new data center contracts or procurement vehicles. Further, any 
+new data center contract or procurement vehicle must require the contractor to report the 
+quarterly average PUE of the contracted facility<sup id="footnote-citation-22"><a href="#footnote-22">22</a></sup> to the contracting agency, except where that 
+data center’s PUE is already being reported directly to OMB or GSA through participation in a 
+multi-agency service program. Agencies are encouraged to require the same for extension of 
+existing vehicles.  PUE reporting is not required for cloud services. 
+ 
+</p>
+<h3>Automated Infrastructure Management 
+ 
+</h3>
+<p>Agencies shall replace manual collections and reporting of systems, software, and hardware 
+inventory housed within data centers with automated monitoring, inventory, and management 
+tools (e.g., data center infrastructure management) by the end of fiscal year 2018.  These tools 
+shall provide the capability to, at a minimum, measure progress toward the server utilization and 
+virtualization metrics defined in the Metric Target Values section of this memorandum.<sup id="footnote-citation-23"><a href="#footnote-23">23</a></sup> 
+ 
+</p>
+<p>Any data center initiation, significant expansion, or migration project that receives Development, 
+Modernization, and Enhancement (DM&amp;E) funds in fiscal year 2017 and beyond must 
+immediately implement automated monitoring and management tools. However, agencies are 
+strongly encouraged to implement automated monitoring and management tools throughout their 
+data centers immediately.  
+                                                         
+ 
+</p>
+<p>To the extent permissible under the FAR, agencies must include automated infrastructure 
+management requirements for all new data center service contracts or procurement vehicles. 
+Further, any new data center contractor procurement vehicle must require the contractor to report 
+to the contracting agency whether the contracted facility utilizes automated infrastructure 
+management, except where such data is already being reported directly to OMB or GSA through 
+participation in a multi-agency service program. Agencies are encouraged to require the same for 
+extension of existing vehicles. 
+ 
+</p>
+<p>GSA shall make available an acquisition vehicle for automated monitoring and management 
+tools to support agency needs. Once established, agencies shall not issue new solicitations for 
+these requirements unless they have developed a business case, approved by the agency’s CIO 
+and shared with OMB, to establish that the separate procurement of these needs results in better 
+value, considering price and other appropriate factors.  
+ 
+</p>
+<h2>Metric Target Values 
+ 
+</h2>
+<p>OMB will measure agency progress for this initiative using the following optimization, cost 
+savings, and closure metrics and goals on a quarterly basis, by way of agencies’ quarterly data 
+center inventory submissions. These optimization, cost-savings, and closure metrics and goals 
+apply to all data centers at agency facilities.  
+ 
+</p>
+<h3>Goal 1: Optimization 
+ 
+</h3>
+<p>The following optimization metrics are listed in order of priority. Agencies shall achieve and 
+maintain all listed target values by the end of fiscal year 2018: 
+ 
+Table 1. Government-wide Optimization Targets for Tiered Data Centers<sup id="footnote-citation-24"><a href="#footnote-24">24</a></sup> 
+Definition 
+Calculation 
+FYE 2018 
+Target Value 
+Total GFA of Energy Metered 
+Data Centers 
+Total GFA of All Tiered Data 
+Centers 
+ 
+Total Energy Used 
+Total IT Equipment Energy 
+Used 
+ 
+100% 
+≤ 1.5 (≤ 1.4 for 
+new data 
+centers) 
+Metric 
+Energy 
+Metering 
+(%) Percent of total gross 
+floor area (GFA)<sup id="footnote-citation-25"><a href="#footnote-25">25</a></sup>  in an 
+agency’s tiered data center 
+inventory located in tiered 
+data centers that have power 
+metering. 
+Power Usage 
+Effectiveness 
+(PUE)<sup id="footnote-citation-26"><a href="#footnote-26">26</a></sup> 
+(Ratio) Proportion of total 
+data center energy used by 
+IT equipment. 
+                                                        
+ 
+Table 1. Government-wide Optimization Targets for Tiered Data Centers<sup id="footnote-citation-24"><a href="#footnote-24">24</a></sup> 
+Metric 
+Definition 
+Calculation 
+FYE 2018 
+Target Value 
+Virtualization 
+(Ratio) Ratio of operating 
+systems (OS) to physical 
+servers. 
+Total Server 
+Count  
+Total Physical Servers 
++  Total Virtual 
+OS 
+ 
+≥ 4 
+≥ 65% 
+≥ 80% 
+Server 
+Utilization &amp; 
+Automated 
+Monitoring 
+Facility 
+Utilization 
+(%) Percent of time busy 
+(measured as 1 – percent of 
+time spent idle), measured 
+directly by continuous, 
+automated monitoring 
+software,<sup id="footnote-citation-27"><a href="#footnote-27">27</a></sup> discounted by the 
+fraction of data centers fully 
+equipped with automated 
+monitoring. 
+(%) Portion of total gross 
+floor area in tiered data 
+centers that is actively 
+utilized for racks that contain 
+IT equipment. 
+ 
+Average 
+Server 
+Utilization 
+* 
+Percent of 
+Data Centers Fully 
+Equipped with 
+Automated 
+Monitoring 
+ 
+ 
+Total Active 
+Rack Count28  *  30 sq. ft. 
+Total Gross Floor Area 
+  
+</p>
+<p>Only the Server Utilization &amp; Automated Monitoring optimization metric shall apply to non-
+tiered data centers. High-performance computing (HPC) nodes can be excluded from 
+calculations of Virtualization and Server Utilization &amp; Automated Monitoring. 
+ 
+</p>
+<h3>Goal 2: Cost Savings and Avoidance 
+ 
+</h3>
+<p>Agencies shall, by the end of fiscal year 2018, reduce Government-wide annual costs attributable 
+to physical data centers by at least 25%, relative to the fiscal year 2016 IT Infrastructure 
+Spending data submitted to the Federal IT Dashboard.<sup id="footnote-citation-29"><a href="#footnote-29">29</a></sup> Agencies shall collectively achieve the 
+following amounts of savings (combined cost savings and cost avoidance)<sup id="footnote-citation-30"><a href="#footnote-30">30</a></sup> in each of fiscal 
+years 2016, 2017, and 2018: 
+ 
+                                                        
+ 
+Table 2. Cost Savings Target  
+FY2014 Physical Data 
+Center Spending 
+$5.4 billion 
+Total Savings Targeted 
+by  
+FYE 2018 
+$2.7 billion 
+9 
+ 
+</p>
+<p>Within 30 days after publication of this document, OMB OFCIO will set individual cost savings 
+and cost avoidance goals for each agency. 
+ 
+</p>
+<h3>Goal 3: Closed Data Centers 
+ 
+</h3>
+<p>In all cases, the term “closed” for data centers shall refer exclusively to tiered or non-tiered data 
+centers that: a) no longer consume power for physical servers; or b) no longer house physical 
+servers (whether in a production, test, stage, development, or any other environment).<sup id="footnote-citation-31"><a href="#footnote-31">31</a></sup> 
+ 
+</p>
+<p>Based on the number of data centers designated by the agencies as already undergoing some part 
+of the closure process, agencies currently plan to close 22% of tiered data centers and 50% of 
+non-tiered, non-cloud data centers, for a total of 44% of all Federal data centers. OMB’s goal for 
+the DCOI is informed by, but exceeds, agencies’ existing closure plans. 
+ 
+</p>
+<p>By the end of fiscal year 2018, agencies shall close at least 25% of tiered data centers 
+government-wide, excluding those approved as inter-agency shared services provider data 
+centers. Furthermore, agencies must close at least 60% of non-tiered data centers government-
+wide.<sup id="footnote-citation-32"><a href="#footnote-32">32</a></sup> This target will result in the closure of approximately 52% of the overall Federal data 
+center inventory and a reduction of approximately 31%<sup id="footnote-citation-33"><a href="#footnote-33">33</a></sup> in the gross floor area occupied by data 
+centers government-wide. Agencies shall prioritize the closure of data centers that are unable to 
+meet applicable PUE optimization targets and/or pose management or security challenges due to 
+age.  
+ 
+</p>
+<p>In the long term, all agencies should continually strive to close all non-tiered data centers. Server 
+rooms and closets pose security risks and management challenges and are an inefficient use of 
+resources. As such, although at least 60% of non-tiered data centers are required to be closed 
+before the end of fiscal year 2018, OMB expects that agencies will consider all such facilities as 
+temporary and work to close them. 
+ 
+</p>
+<p>Within 30 days after publication of this document, OMB OFCIO will share with each agency its 
+individual goal for data center closures, specifying the respective number of tiered and non-tiered 
+data centers the agency must close. OMB may exclude from these agency-specific targets data 
+centers that are physically inseparable from non-IT hardware (e.g. simulation and modeling 
+devices, sensors, etc.) and that perform a specific, non-standard set of tasks (e.g. do not provide 
+general purpose computing or storage services to Federal facilities). 
+                                                        
+ 
+ 
+</p>
+<h2>Reporting 
+ 
+</h2>
+<h3>Compliance Measurement 
+ 
+</h3>
+<p>Data will be collected quarterly on an agency-by-agency basis through the IDC, as follows: 
+ 
+</p>
+<ol><li>Agencies must continue to maintain complete inventories of all data center facilities, 
+closure/consolidation plans, and properties of each facility owned, operated, or 
+maintained by or on behalf of the agency. 
+</li>
+<li>Agencies must include progress toward meeting all optimization metric target values.<sup id="footnote-citation-34"><a href="#footnote-34">34</a></sup> 
+</li>
+<li>Agencies must evaluate the costs of operating and maintaining current facilities and 
+develop year-by-year targets for cost savings and cost avoidance due to consolidation and 
+optimization for fiscal years 2016 through 2018. Agencies shall report all realized cost 
+savings and cost avoidance under the DCOI. 
+ 
+</li>
+</ol>
+<h3>Strategic Plan  
+ 
+</h3>
+<p>In accordance with FITARA,<sup id="footnote-citation-35"><a href="#footnote-35">35</a></sup> beginning in fiscal year 2016, each agency head shall annually 
+publish a Strategic Plan to describe the agency’s consolidation and optimization strategy for 
+fiscal years 2016, 2017, and 2018.  The DCOI Strategic Plan and milestones described below 
+replace existing FDCCI requirements for consolidation plans.  
+ 
+</p>
+<p>Agencies DCOI Strategic Plans must include, at a minimum, the following: 
+ 
+</p>
+<ol><li>Planned and achieved performance levels for each optimization metric, by year; 
+</li>
+<li>Planned and achieved closures, by year;  
+</li>
+<li>An explanation for any optimization metrics and closures for which the agency did not 
+meet the planned level in a previous Strategic Plan; 
+</li>
+<li>Year-by-year calculations of target and actual agency-wide spending and cost savings on 
+data centers from fiscal years 2016 through 2018, including: 
+<ol><li>A description of any initial costs for data center consolidation and optimization; 
+</li>
+</ol>
+</li>
+<li>5.  Historical costs, cost savings, and cost avoidances due to data center consolidation and 
+optimization through fiscal year 2015; and 
+</li>
+<li>A statement from the agency CIO stating whether the agency has complied with all 
+reporting requirements in this memorandum and the data center requirements of 
+FITARA. If the agency has not complied with all reporting requirements, the agency 
+must provide a statement describing the reasons for not complying. 
+<ol><li>Life cycle cost savings and other improvements (including those beyond fiscal 
+and 
+year 2018, if applicable); 
+ 
+                                                        
+ 
+ 
+</li>
+</ol>
+</li>
+</ol>
+<p>Agencies are required to publish their Strategic Plans at [agency].gov/digitalstrategy under a 
+section entitled, “Data Center Optimization Initiative Strategic Plans,” within 60 days of the 
+issuance of this memorandum.  Subsequent Strategic Plan updates shall be due on April 14, 2017 
+and April 13, 2018.  Strategic plans shall also be made available in a machine-readable JSON 
+format at [agency].gov/digitalstrategy/datacenteroptimizationstrategicplan.json.  OMB will 
+provide instructions to agencies, including a schema, at https://management.cio.gov/schema 
+within 5 days of the issuance of this memorandum. 
+Agencies shall furthermore update their [agency].gov/digitalstrategy/FITARAmilestones.json 
+files, also posted on their websites, to identify, at a minimum, 5 milestones per fiscal year to be 
+achieved through the DCOI.  DCOI milestones shall be updated quarterly as progress is achieved 
+and shall be reviewed in quarterly PortfolioStat sessions with agencies’ OMB desk officers.  
+ 
+</p>
+<h2>Transparency 
+ 
+</h2>
+<p>Under FITARA,<sup id="footnote-citation-36"><a href="#footnote-36">36</a></sup> OMB must make publicly available agencies’ progress toward the goals 
+established herein and relative to agencies’ Strategic Plans.  
+ 
+</p>
+<p>To this end, beginning in 2016, OMB will report on government-wide and agency-specific data 
+center progress as part of the IT Dashboard, which will display: 
+ 
+</p>
+<ul><li>Planned and achieved data center closures by agency; 
+</li>
+<li>Government-wide and agency progress toward meeting applicable optimization targets; 
+</li>
+<li>Cumulative cost savings and cost avoidance realized through the implementation of the 
+DCOI and prior initiatives; and 
+</li>
+<li>Annual data center investment spending per agency, including investment transition 
+costs, cost savings projections, progress made against projections and improvements 
+realized through the implementation of the strategy. 
+</li>
+</ul>
+<h2> Community Support 
+ 
+</h2>
+<p>Executive agencies are encouraged to join the Data Centers listserv by emailing 
+listserv@listserv.gsa.gov with no subject and “subscribe datacenters” in the body (from a .gov or 
+.mil email address only). 
+ 
+</p>
+<p>In addition to addressing questions and comments via the Data Centers listserv, 
+https://management.cio.gov will be updated with best practices and other resources as they 
+become available. 
+                                                        
+ 
+</p>
+<h2>Footnotes</h2>
+<dl>
+<dt id="footnote-1">1</dt>
+<dd>The FDCCI was first established by OMB “Memo for CIOs: Federal Data Center Consolidation Initiative,” issued on February 26, 2010, and modified by subsequent memoranda.  <a href="#footnote-citation-1">Back to citation</a></dd>
+<dt id="footnote-2">2</dt>
+<dd>Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-291.  <a href="#footnote-citation-2">Back to citation</a></dd>
+<dt id="footnote-3">3</dt>
+<dd>This office was established in accordance with Section 101 of the E-government Act of 2002, codified at 44 U.S.C. § 3602, and is headed by the Federal government Chief Information Officer.  This office will also be referred to as OMB’s Office of the Federal Chief Information Officer (OFCIO).    <a href="#footnote-citation-3">Back to citation</a></dd>
+<dt id="footnote-4">4</dt>
+<dd>Federal Information Technology Shared Services Strategy, May 2, 2012, https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/shared_services_strategy.pdf.  <a href="#footnote-citation-4">Back to citation</a></dd>
+<dt id="footnote-5">5</dt>
+<dd>See Chief Financial Officers Act of 1990, Pub. L. No. 101–576.  <a href="#footnote-citation-5">Back to citation</a></dd>
+<dt id="footnote-6">6</dt>
+<dd>Per Sec. 834(b)(1)(C) of the FY2015 NDAA, the Department of Defense may submit to OMB, in lieu of the Strategic Plan described in this memorandum, the defense-wide plan and cost savings report required under sections 2867(b)(2) and 2867(d), respectively, of the FY2012 NDAA.  If submitting such plans and reports in lieu of the Strategic Plan, DOD shall ensure all information required by the Strategic Plan is included in the submitted plans and reports.  <a href="#footnote-citation-6">Back to citation</a></dd>
+<dt id="footnote-7">7</dt>
+<dd>Title VIII, Subtitle D of the National Defense Authorization Act (NDAA) for Fiscal Year 2015, Pub. L. No. 113-291.   <a href="#footnote-citation-7">Back to citation</a></dd>
+<dt id="footnote-8">8</dt>
+<dd>OMB Memorandum M-15-14, “Management and Oversight of Federal Information Technology,” June 10, 2015, https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-14.pdf.  <a href="#footnote-citation-8">Back to citation</a></dd>
+<dt id="footnote-9">9</dt>
+<dd>The General Services Administration (GSA) Office of Government-wide Policy (OGP) will coordinate with OMB to define thresholds for what constitutes “significant” expansion within 60 days of publication of this memorandum.  <a href="#footnote-citation-9">Back to citation</a></dd>
+<dt id="footnote-10">10</dt>
+<dd>Data centers certified by GSA OGP as Inter-agency Shared Service Provider data centers are excluded from this development freeze.  <a href="#footnote-citation-10">Back to citation</a></dd>
+<dt id="footnote-11">11</dt>
+<dd>This requirement does not apply to GSA OGP designated inter-agency shared services data centers.  <a href="#footnote-citation-11">Back to citation</a></dd>
+<dt id="footnote-12">12</dt>
+<dd>Federal Cloud Computing Strategy, February 8, 2011, https://www.whitehouse.gov/sites/default/files/omb/assets/egov_docs/federal-cloud-computing-strategy.pdf.  <a href="#footnote-citation-12">Back to citation</a></dd>
+<dt id="footnote-13">13</dt>
+<dd>Ibid.  <a href="#footnote-citation-13">Back to citation</a></dd>
+<dt id="footnote-14">14</dt>
+<dd>See FY2015 NDAA Sec. 834(3)(c).  <a href="#footnote-citation-14">Back to citation</a></dd>
+<dt id="footnote-15">15</dt>
+<dd>Formed in 2004, lines of business (LOB) are cross-agency initiatives to define, design, implement and monitor a set of common solutions for government-wide business functions, processes, or desires capabilities. Each LOB is governed by a Managing Partner which is designated as the lead organization responsible for managing the business requirements of their community.  <a href="#footnote-citation-15">Back to citation</a></dd>
+<dt id="footnote-16">16</dt>
+<dd>Data centers containing only print servers that were previously reported as “closed” shall remain classified as closed data centers in agencies’ data center reporting.  <a href="#footnote-citation-16">Back to citation</a></dd>
+<dt id="footnote-17">17</dt>
+<dd>The term “tiered” and the definitions that follow are derived from the Uptime Institute’s Tier Classification System; however, this shall not be construed as requiring any certification in order for a data center to be considered tiered by OMB.  <a href="#footnote-citation-17">Back to citation</a></dd>
+<dt id="footnote-18">18</dt>
+<dd>Data centers previously classified as tiered in past inventories will automatically be classified as tiered under the DCOI.  <a href="#footnote-citation-18">Back to citation</a></dd>
+<dt id="footnote-19">19</dt>
+<dd>Executive Order, “Planning for Federal Sustainability in the Next Decade” https://www.whitehouse.gov/the-press-office/2015/03/19/executive-order-planning-federal-sustainability-next-decade.    <a href="#footnote-citation-19">Back to citation</a></dd>
+<dt id="footnote-20">20</dt>
+<dd>While Executive Order 13693 requires advanced energy metering in all data centers, OMB will monitor PUE for tiered data centers only.  <a href="#footnote-citation-20">Back to citation</a></dd>
+<dt id="footnote-21">21</dt>
+<dd>See “Implementing Instructions for Executive Order 13693, ‘Planning for Federal Sustainability in the Next Decade’” https://www.whitehouse.gov/sites/default/files/docs/eo_13693_implementing_instructions_june_10_2015.pdf.   <a href="#footnote-citation-21">Back to citation</a></dd>
+<dt id="footnote-22">22</dt>
+<dd>This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger facility; however, if PUE metrics are available specific to the agency’s use, that is preferred.  <a href="#footnote-citation-22">Back to citation</a></dd>
+<dt id="footnote-23">23</dt>
+<dd>For non-tiered data centers, only automated monitoring of server utilization is required.  <a href="#footnote-citation-23">Back to citation</a></dd>
+<dt id="footnote-24">24</dt>
+<dd>While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets will be calculated on a per-data center basis. All other targets will be calculated at the agency inventory-level.  <a href="#footnote-citation-24">Back to citation</a></dd>
+<dt id="footnote-25">25</dt>
+<dd>“Total gross floor area” is defined as total square footage available for IT equipment and includes all associated corridors, walkways, and air circulation requirements. This does not include office space, mechanical rooms, or storage areas.  <a href="#footnote-citation-25">Back to citation</a></dd>
+<dt id="footnote-26">26</dt>
+<dd>PUE shall be calculated by OMB based on quarterly average IT and facility electricity usage data.   <a href="#footnote-citation-26">Back to citation</a></dd>
+<dt id="footnote-27">27</dt>
+<dd>Server utilization shall be collected continuously and reported as a quarterly average.  <a href="#footnote-citation-27">Back to citation</a></dd>
+<dt id="footnote-28">28</dt>
+<dd>“Active” racks are those that have IT equipment consuming electricity. </dd>
+<dt id="footnote-29">29</dt>
+<dd>Benchmarked against the sum of all non-cloud data center costs (including data center labor, software, hardware, electricity, and facility) found in physical data center fields of the IT Inventory Summary Table of the IT Dashboard.  <a href="#footnote-citation-29">Back to citation</a></dd>
+<dt id="footnote-30">30</dt>
+<dd>Consistent with OMB Circular A-131, the term “cost savings” refers to “a reduction in actual expenditures below the projected level of costs to achieve a specific objective,” and the term “cost avoidance” refers to “an action taken in the immediate time frame that will decrease costs in the future.”  <a href="#footnote-citation-30">Back to citation</a></dd>
+<dt id="footnote-31">31</dt>
+<dd>Excludes print servers.  <a href="#footnote-citation-31">Back to citation</a></dd>
+<dt id="footnote-32">32</dt>
+<dd>The baseline number of data centers is based on the agencies’ August 31, 2015, data center inventory submissions, as collected by OMB OFCIO through the Integrated Data Collection.  <a href="#footnote-citation-32">Back to citation</a></dd>
+<dt id="footnote-33">33</dt>
+<dd>Estimated reduction in gross floor area of data centers is approximate and has been based on the average size, in square feet, of the data centers of each type to be closed.  <a href="#footnote-citation-33">Back to citation</a></dd>
+<dt id="footnote-34">34</dt>
+<dd>Note: Agencies participating as a tenant in an inter-agency shared services provider data center are not required to report metric values to OMB. The provider will report this data to OMB.  <a href="#footnote-citation-34">Back to citation</a></dd>
+<dt id="footnote-35">35</dt>
+<dd>See FITARA Section 834(b)(1)(A)-(E).  <a href="#footnote-citation-35">Back to citation</a></dd>
+<dt id="footnote-36">36</dt>
+<dd>See 2015 NDAA Section 834(b)(2)(C).  <a href="#footnote-citation-36">Back to citation</a></dd>
+</dl>


### PR DESCRIPTION
Unlike the current "html" output, this actually attempts to export the PDF as *semantic* HTML, e.g. using `<h1>`, `<li>`, `<p>` and other semantic tags. No stylesheet is provided with the HTML, so all styling is done according to the user-agent's default styling of the semantic tags.

The code for this is horrible. ~~I don't even know if we'll end up committing this or not, I just wanted to see the document output in a format that didn't look like junk.~~ Might as well merge it though, we can always remove it if we want.

