### PR TITLE
Add a 'cli.py runserver' command that lets users browse PDFs and conversions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,6 @@
+import os
 import sys
+import subprocess
 
 import click
 
@@ -12,6 +14,7 @@ import ombpdf.html
 import ombpdf.pagenumbers
 import ombpdf.headings
 import ombpdf.semhtml
+import ombpdf.webapp
 
 
 def get_doc(filename):
@@ -92,6 +95,21 @@ def semhtml(filename):
 
     content = ombpdf.semhtml.to_html(get_doc(filename)).encode('utf-8')
     sys.stdout.buffer.write(content)
+
+
+@cli.command()
+def runserver():
+    "Run a web server that lets you browse PDFs and their conversions."
+
+    env = {}
+    env.update(os.environ)
+    env.update({
+        'FLASK_APP': os.path.join('ombpdf', 'webapp', '__init__.py'),
+        'FLASK_DEBUG': '1',
+    })
+
+    popen = subprocess.Popen(['flask', 'run'], env=env)
+    popen.wait()
 
 
 if __name__ == '__main__':

--- a/ombpdf/webapp/__init__.py
+++ b/ombpdf/webapp/__init__.py
@@ -1,0 +1,64 @@
+from flask import Flask, render_template, Response
+from werkzeug.routing import BaseConverter, ValidationError
+
+from ombpdf.download_pdfs import ROOT_DIR as DATA_DIR
+from ombpdf.document import OMBDocument
+from ombpdf import html, semhtml
+
+
+class PdfPathConverter(BaseConverter):
+    def __init__(self, url_map):
+        super().__init__(url_map)
+        self.regex = r'[0-9A-Za-z\/_\-]+\.pdf'
+
+    def to_python(self, value):
+        pdfmap = get_pdfmap()
+        if value in pdfmap:
+            return pdfmap[value]
+        raise ValidationError()
+
+    def to_url(self, value):
+        return to_urlpath(value)
+
+
+app = Flask(__name__)
+app.url_map.converters['pdfpath'] = PdfPathConverter
+
+
+def to_urlpath(path):
+    return '/'.join(path.relative_to(DATA_DIR).parts)
+
+
+def get_pdfmap():
+    pdfmap = {}
+    for path in DATA_DIR.glob('**/*.pdf'):
+        pdfmap[to_urlpath(path)] = path
+    return pdfmap
+
+
+def to_doc(path):
+    return OMBDocument.from_file(path.open('rb'))
+
+
+@app.route('/')
+def index():
+    return render_template(
+        'index.html',
+        name=__name__,
+        pdfmap=get_pdfmap(),
+    )
+
+
+@app.route('/raw/<pdfpath:pdf>')
+def raw_pdf(pdf):
+    return Response(pdf.read_bytes(), mimetype='application/pdf')
+
+
+@app.route('/html/<pdfpath:pdf>')
+def html_pdf(pdf):
+    return html.to_html(to_doc(pdf))
+
+
+@app.route('/semhtml/<pdfpath:pdf>')
+def semhtml_pdf(pdf):
+    return semhtml.to_html(to_doc(pdf))

--- a/ombpdf/webapp/templates/index.html
+++ b/ombpdf/webapp/templates/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>{{ name }}</title>
+<h1>{{ name }}</h1>
+<table border="1" cellpadding="5px">
+  <thead>
+    <tr>
+      <th>Raw PDF</th>
+      <th>Annotated layout (HTML)</th>
+      <th>Semantic HTML</th>
+  </thead>
+  <tbody>
+    {% for name, path in pdfmap.items() %}
+    <tr>
+      <td>
+        <code><a href="{{ url_for('raw_pdf', pdf=path) }}">{{ name }}</a></code>
+      </td>
+      <td>
+        <a href="{{ url_for('html_pdf', pdf=path) }}">View annotated layout</a>
+      </td>
+      <td>
+        <a href="{{ url_for('semhtml_pdf', pdf=path) }}">View semantic HTML</a>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,12 @@
 pdfminer.six==20170720
-pytest==3.2.5
+
+# Needed for downloading PDFs only.
 requests==2.18.4
 tqdm==4.19.4
+
+# Needed for the CLI only.
 click==6.7
+flask==0.12.2
+
+# Needed for testing only.
+pytest==3.2.5

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,32 @@
+import pytest
+
+from ombpdf.download_pdfs import download
+import ombpdf.webapp
+
+
+PDFPATH = '2016/m_16_19_1.pdf'
+
+
+@pytest.fixture
+def webapp():
+    # Ensure we have at least one PDF for the webapp to process.
+    download(PDFPATH)
+
+    ombpdf.webapp.app.testing = True
+    return ombpdf.webapp.app.test_client()
+
+
+def test_index_works(webapp):
+    assert PDFPATH.encode('ascii') in webapp.get('/').data
+
+
+def test_raw_pdf_works(webapp):
+    assert webapp.get(f'/raw/{PDFPATH}').status_code == 200
+
+
+def test_html_pdf_works(webapp):
+    assert webapp.get(f'/html/{PDFPATH}').status_code == 200
+
+
+def test_semhtml_pdf_works(webapp):
+    assert webapp.get(f'/semhtml/{PDFPATH}').status_code == 200


### PR DESCRIPTION
This adds a simple Flask-based webapp that makes it easier to browse PDFs in the `data` directory, and and their various conversions:

> ![ombpdf-webapp](https://user-images.githubusercontent.com/124687/33439592-d16bfc5a-d5bb-11e7-8154-ec0f3611f7d8.png)

The webapp can be launched via `python cli.py runserver`.  It's launched in Flask's debug mode, so developers can change things and instantly see results.

Because the server browses PDFs in the `data` directory, users should run `python cli.py download` first, so they actually have PDFs to browse.

## To do

- [x] Add tests, maybe.
