### PR TITLE
Make annotator behavior more predictable and fault tolerant

### DIFF
--- a/ombpdf/annotators.py
+++ b/ombpdf/annotators.py
@@ -1,15 +1,16 @@
 import importlib
+from collections import OrderedDict
 
 
-ANNOTATORS = {
-    'footnotes': 'ombpdf.footnotes.annotate_footnotes',
-    'footnote_citations': 'ombpdf.footnotes.annotate_citations',
-    'page_numbers': 'ombpdf.pagenumbers.annotate_page_numbers',
-    'paragraphs': 'ombpdf.paragraphs.annotate_paragraphs',
-    'underlines': 'ombpdf.underlines.set_underlines',
-    'lists': 'ombpdf.lists.annotate_lists',
-    'headings': 'ombpdf.headings.annotate_headings',
-}
+ANNOTATORS = OrderedDict([
+    ('footnotes', 'ombpdf.footnotes.annotate_footnotes'),
+    ('footnote_citations', 'ombpdf.footnotes.annotate_citations'),
+    ('page_numbers', 'ombpdf.pagenumbers.annotate_page_numbers'),
+    ('paragraphs', 'ombpdf.paragraphs.annotate_paragraphs'),
+    ('underlines', 'ombpdf.underlines.set_underlines'),
+    ('lists', 'ombpdf.lists.annotate_lists'),
+    ('headings', 'ombpdf.headings.annotate_headings'),
+])
 
 _annotator_funcs = {}
 

--- a/ombpdf/document.py
+++ b/ombpdf/document.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from decimal import Decimal
+import logging
 import math
 
 from pdfminer import layout
@@ -7,6 +8,9 @@ from pdfminer import layout
 from . import fontsize
 from . import util
 from .annotators import AnnotatorTracker
+
+
+logger = logging.getLogger(__name__)
 
 
 class OMBDocument:
@@ -64,8 +68,9 @@ OMBHeading = namedtuple('OMBHeading', ['level'])
 class AnnotatableMixin:
     def set_annotation(self, annotation):
         if self.annotation is not None and self.annotation != annotation:
-            raise AssertionError(f"Document item already has a different "
-                                 f"annotation")
+            logger.warn(
+                f"Replacing {self.annotation} with {annotation}."
+            )
         self.annotation = annotation
 
 


### PR DESCRIPTION
As suggested in #14, this PR makes annotator behavior more predictable by

1. converting `ombpdf.annotators.ANNOTATORS` into an `OrderedDict`, and
2. making `set_annotation()` log a warning in the case of a pre-existing annotation, rather than raising an exception.
