### PR TITLE
Footnotes versus pagenumbers versus lists

### DIFF
--- a/ombpdf/annotators.py
+++ b/ombpdf/annotators.py
@@ -1,5 +1,14 @@
 import importlib
 
+ORDERED_ANNOTATORS = (
+    'page_numbers',
+    'footnotes',
+    'footnote_citations',
+    'paragraphs',
+    'underlines',
+    'lists',
+    'headings'
+)
 
 ANNOTATORS = {
     'footnotes': 'ombpdf.footnotes.annotate_footnotes',
@@ -37,7 +46,7 @@ class AnnotatorTracker:
             self._has_run[name] = False
 
     def require_all(self):
-        self.require(*ANNOTATORS.keys())
+        self.require(*ORDERED_ANNOTATORS)
 
     def require(self, *names):
         for name in names:

--- a/ombpdf/footnotes.py
+++ b/ombpdf/footnotes.py
@@ -4,7 +4,12 @@ from textwrap import TextWrapper
 
 from pdfminer import layout
 
-from .document import OMBDocument, OMBFootnoteCitation, OMBFootnote
+from .document import (
+    OMBDocument,
+    OMBFootnoteCitation,
+    OMBFootnote,
+    OMBPageNumber
+)
 from . import util
 from .fontsize import FontSize
 
@@ -61,6 +66,12 @@ def annotate_footnotes(doc):
         curr_footnote = None
 
     for line in doc.lines:
+        if line.annotation is not None:
+            # If the annotation is page number, we assume that the
+            # page number annotation is correct and that the
+            # footnote detection is being too greedy.
+            if line.annotation.__class__.__name__ == "OMBPageNumber":
+                continue
         big_chars = [
             char for char in line
             if char.fontsize.size >= doc.paragraph_fontsize.size

--- a/ombpdf/html.py
+++ b/ombpdf/html.py
@@ -46,10 +46,11 @@ def id_for_footnote(fnum):
 
 
 def to_html(doc):
+    # Page numbers and footnotes can clash; handle page numbers first.
+    pagenumbers.annotate_page_numbers(doc)
     footnotes.annotate_citations(doc)
     footnotes.annotate_footnotes(doc)
     underlines.set_underlines(doc)
-    pagenumbers.annotate_page_numbers(doc)
 
     footnotes_defined = []
     chunks = [f'<title>HTML output for {doc.filename}</title>\n']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,13 @@ def m_16_19_pages():
 @pytest.fixture
 def m_16_19_doc(m_16_19_pages):
     return document.OMBDocument(m_16_19_pages, filename='m_16_19_1.pdf')
+
+
+@pytest.fixture
+def m_15_17_pages():
+    return read_pages('2015/m-15-17.pdf')
+
+
+@pytest.fixture
+def m_15_17_doc(m_15_17_pages):
+    return document.OMBDocument(m_15_17_pages, filename='m-15-17.pdf')

--- a/tests/test_footnotes.py
+++ b/tests/test_footnotes.py
@@ -1,4 +1,4 @@
-from ombpdf import footnotes
+from ombpdf import footnotes, pagenumbers
 
 
 def test_annotate_citations_works(m_16_19_doc):
@@ -12,6 +12,8 @@ def test_annotate_citations_works(m_16_19_doc):
 
 
 def test_annotate_footnotes_works(m_16_19_doc):
+    # Page numbers and footnotes can clash; handle page numbers first.
+    pagenumbers.annotate_page_numbers(m_16_19_doc)
     notes = footnotes.annotate_footnotes(m_16_19_doc)
     assert notes[:1] == [
         (1, 'The FDCCI was first established by OMB “Memo for CIOs: '
@@ -22,3 +24,31 @@ def test_annotate_footnotes_works(m_16_19_doc):
 
 def test_main_works(m_16_19_doc):
     footnotes.main(m_16_19_doc)
+
+
+def test_main_15_17(m_15_17_doc):
+    footnotes.main(m_15_17_doc)
+
+
+def test_annotate_footnotes_m_15_17(m_15_17_doc):
+    # Page numbers and footnotes can clash; handle page numbers first.
+    pagenumbers.annotate_page_numbers(m_15_17_doc)
+    notes = footnotes.annotate_footnotes(m_15_17_doc)
+
+    assert notes[:2] == [
+        (
+            1,
+            'See U.S. Department of Education, National Center for '
+            'Education Statistics. Public High School Graduation Rates. '
+            'https://nces.ed.gov/programs/coe/indicator coi.asp. \n'
+        ),
+        (
+            2,
+            'See U.S. Department of Education, National Center for '
+            'Education Statistics. Public High School Four-Year On-Time '
+            'Graduation Rates and Event Dropout Rates: School Years '
+            '2010-11 and 2011-12, by Marie C. Stetser and Robert '
+            '\nStillwell, NCES 2014-39 (2014). '
+            'http://nces.ed.gov/pubs2014/201439l.pdf. \n'
+        )
+    ]

--- a/tests/test_footnotes.py
+++ b/tests/test_footnotes.py
@@ -1,4 +1,4 @@
-from ombpdf import footnotes, pagenumbers
+from ombpdf import footnotes, lists, pagenumbers
 
 
 def test_annotate_citations_works(m_16_19_doc):
@@ -34,6 +34,8 @@ def test_annotate_footnotes_m_15_17(m_15_17_doc):
     # Page numbers and footnotes can clash; handle page numbers first.
     pagenumbers.annotate_page_numbers(m_15_17_doc)
     notes = footnotes.annotate_footnotes(m_15_17_doc)
+    # Run this to check that there isn't a clash over lists:
+    lists.annotate_lists(m_15_17_doc)
 
     assert notes[:2] == [
         (


### PR DESCRIPTION
Greed is everywhere.
If you do things in order
There is less conflict.

Orders detection as page numbers, then footnotes, then lists, and adds related tests.