### PR TITLE
Improve detection and comparison of left edges of lines

### DIFF
--- a/ombpdf/lists.py
+++ b/ombpdf/lists.py
@@ -39,6 +39,8 @@ class ListInfo:
 
 
 def annotate_lists(doc):
+    doc.annotators.require('page_numbers', 'footnotes')
+
     list_id = 0
     stack = []
     lists = {}

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -42,3 +42,24 @@ def test_annotate_lists_works(m_16_19_doc):
         is_ordered=True,
         indentation=2,
     )
+
+
+def test_lists_are_annotated_on_m_15_17(m_15_17_doc):
+    lists = annotate_lists(m_15_17_doc)
+    titles = [
+        'Improve Educational Outcomes and Life Outcomes for Native Youth',
+        'Increase Access to Quality Teacher Housing',
+        'Improve Access to the Internet',
+        'Support the Implementation ofthe Indian Child Welfare Act',
+        'Reduce Teen Suicide',
+    ]
+
+    for i in range(1, 6):
+        assert lists[1][i][0].annotation == OMBListItem(
+            list_id=1,
+            number=i,
+            is_ordered=False,
+            indentation=1
+        )
+
+        assert titles[i-1] in ' '.join(str(line) for line in lists[1][i])


### PR DESCRIPTION
M-15-17 was being horribly mis-interpreted in part because a big emblem with text on it was on the top of the front page, which made our layout analyzer think that the left edge of the page was further back than it actually was.

This improves the analyzer by ensuring that at least a certain percentage (currently 10%) of all the lines in the document are at the left edge, ensuring that outliers like the emblem don't make us mis-predict the left edge of the page.

This also improves the situation by "bucketing" all left edges into 2-point increments, ensuring that lines with left edges that are extremely close to each other are viewed as having the same left edge. In particular, this helps the list annotator properly regard bullets in the same list as being at the same level of indentation.
