### PR TITLE
Fix footnote citation detection on slightly-smaller lines

### DIFF
--- a/ombpdf/footnotes.py
+++ b/ombpdf/footnotes.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from textwrap import TextWrapper
 
@@ -19,6 +18,10 @@ NUMBER_RE = re.compile(r'[0-9]')
 FOOTNOTE_RE = re.compile(r'([0-9]+) (.+)')
 
 
+def is_significantly_smaller(size, normal_size, gap=0.2):
+    return float(normal_size - size) > float(gap)
+
+
 def annotate_citations(doc):
     citations = []
     for line in doc.lines:
@@ -35,7 +38,8 @@ def annotate_citations(doc):
             citations.append(citation)
 
         for char in line:
-            if char.fontsize.size < doc.paragraph_fontsize.size:
+            if is_significantly_smaller(char.fontsize.size,
+                                        doc.paragraph_fontsize.size):
                 if NUMBER_RE.match(str(char)):
                     if prev_paragraph_chars:
                         curr_citation.append(char)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,13 @@ def m_15_17_pages():
 @pytest.fixture
 def m_15_17_doc(m_15_17_pages):
     return document.OMBDocument(m_15_17_pages, filename='m-15-17.pdf')
+
+
+@pytest.fixture
+def m_17_11_0_pages():
+    return read_pages('2017/m-17-11_0.pdf')
+
+
+@pytest.fixture
+def m_17_11_0_doc(m_17_11_0_pages):
+    return document.OMBDocument(m_17_11_0_pages, filename='m-17-11_0.pdf')

--- a/tests/test_footnotes.py
+++ b/tests/test_footnotes.py
@@ -54,3 +54,30 @@ def test_annotate_footnotes_m_15_17(m_15_17_doc):
             'http://nces.ed.gov/pubs2014/201439l.pdf. \n'
         )
     ]
+
+
+def test_annotate_footnotes_m_17_11_0(m_17_11_0_doc):
+    # Page numbers and footnotes can clash; handle page numbers first.
+    pagenumbers.annotate_page_numbers(m_17_11_0_doc)
+    notes = footnotes.annotate_footnotes(m_17_11_0_doc)
+    citations = footnotes.annotate_citations(m_17_11_0_doc)
+    # Run this to check that there isn't a clash over lists:
+    lists.annotate_lists(m_17_11_0_doc)
+
+    # We're testing this footnote specifically because the source line for this
+    # footnote citation contains text that's slightly smaller than most of the
+    # text in the document, which was previously throwing off detection of this
+    # footnote citation.
+    assert notes[5] == (
+        6,
+        'Id. at§ 5(a). Example: The Program Fraud Civil Remedies Act '
+        'penalty was increased to $10,781in2016, in  accordance with '
+        'the catch-up adjustment requirement ofthe 2015 Act.  '
+        '$10,781x1.01636 = $10,957.38  When rounded to the nearest '
+        'dollar, the new penalty is $10,957.  '
+    )
+
+    assert citations[5] == (
+        6,
+        'living adjustment. "'
+    )


### PR DESCRIPTION
A small difference
Is not always important.
Ignore it sometimes.

Previously we were checking if a given set of characters had a lower font size than the base font size for the document. Now, check to see if the font size is lower by a significant amount (here defined arbitrarily as 0.2).