### PR TITLE
Add raw layout view

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,6 +15,7 @@ import ombpdf.pagenumbers
 import ombpdf.headings
 import ombpdf.semhtml
 import ombpdf.webapp
+import ombpdf.rawlayout
 
 
 def get_doc(filename):
@@ -94,6 +95,15 @@ def semhtml(filename):
     "Convert the given PDF to semantic HTML."
 
     content = ombpdf.semhtml.to_html(get_doc(filename)).encode('utf-8')
+    sys.stdout.buffer.write(content)
+
+
+@cli.command()
+@click.argument('filename')
+def rawlayout(filename):
+    "Show HTML for the raw layout (bounding boxes, etc) of the given PDF."
+
+    content = ombpdf.rawlayout.to_html(get_doc(filename)).encode('utf-8')
     sys.stdout.buffer.write(content)
 
 

--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -39,17 +39,19 @@ PREAMBLE = """\
 </p>
 """
 
-class PxStyleAttr:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
+def to_px_style_attr(**kwargs):
+    '''
+    >>> to_px_style_attr(width=50.12345, height=40.65321)
+    'style="height: 40.65px; width: 50.12px"'
+    '''
 
-    def __str__(self):
-        props = []
-        for name, val in self.kwargs.items():
-            val = Decimal(val).quantize(Decimal('.01'))
-            props.append(f'{name}: {val}px')
-        css = '; '.join(props)
-        return f'style="{css}"'
+    props = []
+    for name, val in kwargs.items():
+        val = Decimal(val).quantize(Decimal('.01'))
+        props.append(f'{name}: {val}px')
+    props.sort()
+    css = '; '.join(props)
+    return f'style="{css}"'
 
 
 def to_html(doc):
@@ -60,15 +62,15 @@ def to_html(doc):
         PREAMBLE,
     ]
     for page in doc.pages:
-        pagestyle = PxStyleAttr(width=page.ltpage.width,
-                                height=page.ltpage.height)
+        pagestyle = to_px_style_attr(width=page.ltpage.width,
+                                     height=page.ltpage.height)
         chunks.append(f'<h2>Page {page.number}</h2>')
         chunks.append(f'<div class="page" {pagestyle}>\n')
         for line in page:
             chunks.append(f'<div class="line" '
                           f'data-str="{escape(str(line))}">\n')
             for char in line:
-                charstyle = PxStyleAttr(
+                charstyle = to_px_style_attr(
                     top=page.ltpage.height - char.ltchar.y0,
                     left=char.ltchar.x0,
                     width=char.ltchar.width,

--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -1,0 +1,81 @@
+from html import escape
+from decimal import Decimal
+
+
+HTML_INTRO = """\
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+html, body {
+    font-family: sans-serif;
+}
+
+.page {
+    border: 1px solid black;
+    position: relative;
+    display: inline-block;
+    overflow: hidden;
+}
+
+.char {
+    box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.75);
+    border-left: 1px solid rgba(0, 0, 0, 0.9);
+    color: lightgray;
+    position: absolute;
+    overflow: hidden;
+    font-size: 9px;
+}
+</style>
+"""
+
+PREAMBLE = """\
+<p>
+  This page is primarily intended to show the bounding boxes of various
+  page elements. In particular, font sizes are not accurate.
+</p>
+<p>
+  Inspect this page with developer tools to obtain more details.
+</p>
+"""
+
+class PxStyleAttr:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __str__(self):
+        props = []
+        for name, val in self.kwargs.items():
+            val = Decimal(val).quantize(Decimal('.01'))
+            props.append(f'{name}: {val}px')
+        css = '; '.join(props)
+        return f'style="{css}"'
+
+
+def to_html(doc):
+    chunks = [
+        HTML_INTRO,
+        f'<title>Raw layout for {doc.filename}</title>\n',
+        f'<h1>Raw layout for <code>{doc.filename}</code></h1>\n',
+        PREAMBLE,
+    ]
+    for page in doc.pages:
+        pagestyle = PxStyleAttr(width=page.ltpage.width,
+                                height=page.ltpage.height)
+        chunks.append(f'<h2>Page {page.number}</h2>')
+        chunks.append(f'<div class="page" {pagestyle}>\n')
+        for line in page:
+            chunks.append(f'<div class="line" '
+                          f'data-str="{escape(str(line))}">\n')
+            for char in line:
+                charstyle = PxStyleAttr(
+                    top=page.ltpage.height - char.ltchar.y0,
+                    left=char.ltchar.x0,
+                    width=char.ltchar.width,
+                    height=char.ltchar.height,
+                )
+                chunks.append(f'<div class="char" {charstyle}>{char}</div>\n')
+            chunks.append(f'</div>')
+        chunks.append(f'</div>\n')
+
+    return ''.join(chunks)

--- a/ombpdf/webapp/__init__.py
+++ b/ombpdf/webapp/__init__.py
@@ -3,7 +3,7 @@ from werkzeug.routing import BaseConverter, ValidationError
 
 from ombpdf.download_pdfs import ROOT_DIR as DATA_DIR
 from ombpdf.document import OMBDocument
-from ombpdf import html, semhtml
+from ombpdf import html, semhtml, rawlayout
 
 
 class PdfPathConverter(BaseConverter):
@@ -62,3 +62,8 @@ def html_pdf(pdf):
 @app.route('/semhtml/<pdfpath:pdf>')
 def semhtml_pdf(pdf):
     return semhtml.to_html(to_doc(pdf))
+
+
+@app.route('/rawlayout/<pdfpath:pdf>')
+def rawlayout_pdf(pdf):
+    return rawlayout.to_html(to_doc(pdf))

--- a/ombpdf/webapp/templates/index.html
+++ b/ombpdf/webapp/templates/index.html
@@ -6,6 +6,7 @@
   <thead>
     <tr>
       <th>Raw PDF</th>
+      <th>Raw layout (HTML)</th>
       <th>Annotated layout (HTML)</th>
       <th>Semantic HTML</th>
   </thead>
@@ -14,6 +15,9 @@
     <tr>
       <td>
         <code><a href="{{ url_for('raw_pdf', pdf=path) }}">{{ name }}</a></code>
+      </td>
+      <td>
+        <a href="{{ url_for('rawlayout_pdf', pdf=path) }}">View raw layout</a>
       </td>
       <td>
         <a href="{{ url_for('html_pdf', pdf=path) }}">View annotated layout</a>

--- a/tests/test_rawlayout.py
+++ b/tests/test_rawlayout.py
@@ -1,0 +1,9 @@
+from ombpdf import rawlayout
+
+
+def test_to_html_works(m_16_19_doc):
+    html = rawlayout.to_html(m_16_19_doc)
+
+    assert 'Raw layout' in html
+    assert 'left:' in html
+    assert 'width:' in html

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -30,3 +30,7 @@ def test_html_pdf_works(webapp):
 
 def test_semhtml_pdf_works(webapp):
     assert webapp.get(f'/semhtml/{PDFPATH}').status_code == 200
+
+
+def test_rawlayout_works(webapp):
+    assert webapp.get(f'/rawlayout/{PDFPATH}').status_code == 200


### PR DESCRIPTION
This adds a debugging view, reachable from the CLI and web app, that I'm calling the "raw layout" view. It's only intended to show the bounding boxes of visual items on the page; font sizes of individual characters, for instance, are always 9px, and only intended to reflect the content of the page rather than the text's appearance.

For instance, here's what the nested list in page 10 of M-16-19 looks like:

> ![rawlayout](https://user-images.githubusercontent.com/124687/33581721-f3f5f5e8-d91f-11e7-88ca-f411fdd572c2.png)

I wanted to make this view so that I could get a better grasp on where pdfminer thinks items on the page are. For instance, as documented in #10, pdfminer actually mis-orders the lines of the above nested list:

> ![html](https://user-images.githubusercontent.com/124687/33348977-3e8a3722-d466-11e7-8205-02c972316e91.png)

I wasn't sure where this bug actually lay, e.g. whether it was pdfminer thinking that the nested list items were in the wrong place on the page, or whether it was something further down the pipeline, in pdfminer's analysis of where the lines were relative to other lines.  It's clear from this new "raw layout" view that the problem is the latter, which will make fixing bugs like #10 and #1 easier.  This could also enable the implementation of layout inference solutions that are superior to pdfminer's.
