### PR TITLE
Show fully-rendered PDF in rawlayout view with pdf.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__/
 venv/
 data/
+node_modules/
+ombpdf/webapp/static/js/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ the [OMB Policy Library][].
 
 ## Quick start
 
-You'll need Python 3.6.
+You'll need Python 3.6 and optionally node JS (to use
+some features of the web app).
 
 First, create and activate a virtualenv, e.g.:
 
@@ -19,6 +20,7 @@ Then install requirements:
 
 ```
 pip install -r requirements.txt
+npm install
 ```
 
 Then run tests:
@@ -27,11 +29,21 @@ Then run tests:
 pytest
 ```
 
-Then run the CLI:
+Then download some PDFs:
 
 ```
-python cli.py --help
+python cli.py download
 ```
+
+Then run the development web app, which lets you
+explore the PDFs and see how our algorithms analyze
+them:
+
+```
+python cli.py runserver
+```
+
+You can visit the app at http://localhost:5000/.
 
 [pdfminer]: https://github.com/pdfminer/pdfminer.six
 [OMB Policy Library]: https://github.com/18F/omb-eregs

--- a/cli.py
+++ b/cli.py
@@ -118,8 +118,16 @@ def runserver():
         'FLASK_DEBUG': '1',
     })
 
-    popen = subprocess.Popen(['flask', 'run'], env=env)
-    popen.wait()
+    frontend = subprocess.Popen([
+        'node',
+        os.path.join('node_modules', 'webpack', 'bin', 'webpack.js'),
+    ])
+
+    try:
+        server = subprocess.Popen(['flask', 'run'], env=env)
+        server.wait()
+    finally:
+        frontend.kill()
 
 
 if __name__ == '__main__':

--- a/cli.py
+++ b/cli.py
@@ -15,7 +15,6 @@ import ombpdf.pagenumbers
 import ombpdf.headings
 import ombpdf.semhtml
 import ombpdf.webapp
-import ombpdf.rawlayout
 
 
 def get_doc(filename):
@@ -95,15 +94,6 @@ def semhtml(filename):
     "Convert the given PDF to semantic HTML."
 
     content = ombpdf.semhtml.to_html(get_doc(filename)).encode('utf-8')
-    sys.stdout.buffer.write(content)
-
-
-@cli.command()
-@click.argument('filename')
-def rawlayout(filename):
-    "Show HTML for the raw layout (bounding boxes, etc) of the given PDF."
-
-    content = ombpdf.rawlayout.to_html(get_doc(filename)).encode('utf-8')
     sys.stdout.buffer.write(content)
 
 

--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -18,14 +18,23 @@ def to_px_style_attr(**kwargs):
 
 
 def to_html(doc):
+    doc.annotators.require_all()
     chunks = []
+    legend = set()
     for page in doc.pages:
         pagestyle = to_px_style_attr(width=page.ltpage.width,
                                      height=page.ltpage.height)
         chunks.append(f'<h2>Page {page.number}</h2>')
         chunks.append(f'<div class="page" {pagestyle}>\n')
         for line in page:
-            chunks.append(f'<div class="line" '
+            line_classes = ['line']
+            if line.annotation is not None:
+                classname = line.annotation.__class__.__name__
+                cssname = f'line-{classname}'
+                line_classes.append(cssname)
+                legend.add((classname, cssname))
+            line_classes = ' '.join(line_classes)
+            chunks.append(f'<div class="{line_classes}" '
                           f'data-str="{escape(str(line))}">\n')
             for char in line:
                 charstyle = to_px_style_attr(
@@ -38,4 +47,4 @@ def to_html(doc):
             chunks.append(f'</div>')
         chunks.append(f'</div>\n')
 
-    return ''.join(chunks)
+    return (''.join(chunks), dict(legend=legend))

--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -29,7 +29,7 @@ def to_html(doc):
             f'<a href="#{page.number}">Page {page.number}</a></h2>'
         )
         chunks.append(f'<div class="page" {pagestyle}>\n')
-        for line in page:
+        for line, lineno in zip(page, range(1, len(page) + 1)):
             line_classes = ['line']
             if line.annotation is not None:
                 classname = line.annotation.__class__.__name__
@@ -38,7 +38,8 @@ def to_html(doc):
                 legend.add((classname, cssname))
             line_classes = ' '.join(line_classes)
             chunks.append(f'<div class="{line_classes}" '
-                          f'data-str="{escape(str(line))}">\n')
+                          f'data-anno="{escape(str(line.annotation))}"'
+                          f'data-lineno="{lineno}">\n')
             for char in line:
                 charstyle = to_px_style_attr(
                     top=page.ltpage.height - char.ltchar.y1,

--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -6,6 +6,16 @@ HTML_INTRO = """\
 <!DOCTYPE html>
 <meta charset="utf-8">
 <style>
+* {
+    box-sizing: border-box;
+}
+
+canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
 html, body {
     font-family: sans-serif;
 }
@@ -18,13 +28,12 @@ html, body {
 }
 
 .char {
-    box-sizing: border-box;
-    background: rgba(0, 0, 0, 0.75);
-    border-left: 1px solid rgba(0, 0, 0, 0.9);
+    background: rgba(0, 255, 0, 0.2);
+/*    border-left: 1px solid blue; */
     color: lightgray;
     position: absolute;
     overflow: hidden;
-    font-size: 9px;
+    font-size: 0;
 }
 </style>
 """
@@ -32,7 +41,7 @@ html, body {
 PREAMBLE = """\
 <p>
   This page is primarily intended to show the bounding boxes of various
-  page elements. In particular, font sizes are not accurate.
+  page elements.
 </p>
 <p>
   Inspect this page with developer tools to obtain more details.
@@ -71,7 +80,7 @@ def to_html(doc):
                           f'data-str="{escape(str(line))}">\n')
             for char in line:
                 charstyle = to_px_style_attr(
-                    top=page.ltpage.height - char.ltchar.y0,
+                    top=page.ltpage.height - char.ltchar.y1,
                     left=char.ltchar.x0,
                     width=char.ltchar.width,
                     height=char.ltchar.height,
@@ -79,5 +88,7 @@ def to_html(doc):
                 chunks.append(f'<div class="char" {charstyle}>{char}</div>\n')
             chunks.append(f'</div>')
         chunks.append(f'</div>\n')
+
+    chunks.append(f'<script src="/static/js/main.bundle.js"></script>')
 
     return ''.join(chunks)

--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -24,7 +24,10 @@ def to_html(doc):
     for page in doc.pages:
         pagestyle = to_px_style_attr(width=page.ltpage.width,
                                      height=page.ltpage.height)
-        chunks.append(f'<h2>Page {page.number}</h2>')
+        chunks.append(
+            f'<h2 id="{page.number}">'
+            f'<a href="#{page.number}">Page {page.number}</a></h2>'
+        )
         chunks.append(f'<div class="page" {pagestyle}>\n')
         for line in page:
             line_classes = ['line']

--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -2,52 +2,6 @@ from html import escape
 from decimal import Decimal
 
 
-HTML_INTRO = """\
-<!DOCTYPE html>
-<meta charset="utf-8">
-<style>
-* {
-    box-sizing: border-box;
-}
-
-canvas {
-    position: absolute;
-    top: 0;
-    left: 0;
-}
-
-html, body {
-    font-family: sans-serif;
-}
-
-.page {
-    border: 1px solid black;
-    position: relative;
-    display: inline-block;
-    overflow: hidden;
-}
-
-.char {
-    background: rgba(0, 255, 0, 0.2);
-/*    border-left: 1px solid blue; */
-    color: lightgray;
-    position: absolute;
-    overflow: hidden;
-    font-size: 0;
-}
-</style>
-"""
-
-PREAMBLE = """\
-<p>
-  This page is primarily intended to show the bounding boxes of various
-  page elements.
-</p>
-<p>
-  Inspect this page with developer tools to obtain more details.
-</p>
-"""
-
 def to_px_style_attr(**kwargs):
     '''
     >>> to_px_style_attr(width=50.12345, height=40.65321)
@@ -64,12 +18,7 @@ def to_px_style_attr(**kwargs):
 
 
 def to_html(doc):
-    chunks = [
-        HTML_INTRO,
-        f'<title>Raw layout for {doc.filename}</title>\n',
-        f'<h1>Raw layout for <code>{doc.filename}</code></h1>\n',
-        PREAMBLE,
-    ]
+    chunks = []
     for page in doc.pages:
         pagestyle = to_px_style_attr(width=page.ltpage.width,
                                      height=page.ltpage.height)
@@ -88,7 +37,5 @@ def to_html(doc):
                 chunks.append(f'<div class="char" {charstyle}>{char}</div>\n')
             chunks.append(f'</div>')
         chunks.append(f'</div>\n')
-
-    chunks.append(f'<script src="/static/js/main.bundle.js"></script>')
 
     return ''.join(chunks)

--- a/ombpdf/webapp/__init__.py
+++ b/ombpdf/webapp/__init__.py
@@ -82,9 +82,12 @@ def rawlayout_pdf(pdf):
         'workerSrc': url_for('static', filename='js/pdf.worker.bundle.js'),
     }
 
+    html, ctx = rawlayout.to_html(doc)
+
     return render_template(
         'rawlayout.html',
         doc=doc,
-        html=Markup(rawlayout.to_html(doc)),
+        html=Markup(html),
         script_params=script_params,
+        **ctx,
     )

--- a/ombpdf/webapp/__init__.py
+++ b/ombpdf/webapp/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, Response, Markup
+from flask import Flask, render_template, Response, Markup, url_for
 from werkzeug.routing import BaseConverter, ValidationError
 
 from ombpdf.download_pdfs import ROOT_DIR as DATA_DIR
@@ -76,8 +76,15 @@ def semhtml_pdf(pdf):
 @app.route('/rawlayout/<pdfpath:pdf>')
 def rawlayout_pdf(pdf):
     doc = to_doc(pdf)
+
+    script_params = {
+        'pdfPath': url_for('raw_pdf', pdf=pdf),
+        'workerSrc': url_for('static', filename='js/pdf.worker.bundle.js'),
+    }
+
     return render_template(
         'rawlayout.html',
         doc=doc,
         html=Markup(rawlayout.to_html(doc)),
+        script_params=script_params,
     )

--- a/ombpdf/webapp/__init__.py
+++ b/ombpdf/webapp/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, Response
+from flask import Flask, render_template, Response, Markup
 from werkzeug.routing import BaseConverter, ValidationError
 
 from ombpdf.download_pdfs import ROOT_DIR as DATA_DIR
@@ -75,4 +75,9 @@ def semhtml_pdf(pdf):
 
 @app.route('/rawlayout/<pdfpath:pdf>')
 def rawlayout_pdf(pdf):
-    return rawlayout.to_html(to_doc(pdf))
+    doc = to_doc(pdf)
+    return render_template(
+        'rawlayout.html',
+        doc=doc,
+        html=Markup(rawlayout.to_html(doc)),
+    )

--- a/ombpdf/webapp/__init__.py
+++ b/ombpdf/webapp/__init__.py
@@ -3,6 +3,7 @@ from werkzeug.routing import BaseConverter, ValidationError
 
 from ombpdf.download_pdfs import ROOT_DIR as DATA_DIR
 from ombpdf.document import OMBDocument
+from ombpdf.util import get_ltpages
 from ombpdf import html, semhtml, rawlayout
 
 
@@ -36,8 +37,16 @@ def get_pdfmap():
     return pdfmap
 
 
+_ltpages_cache = {}
+
 def to_doc(path):
-    return OMBDocument.from_file(path.open('rb'))
+    if path not in _ltpages_cache:
+        with path.open('rb') as fp:
+            _ltpages_cache[path] = get_ltpages(fp)
+    return OMBDocument(
+        _ltpages_cache[path],
+        filename=path.relative_to(DATA_DIR),
+    )
 
 
 @app.route('/')

--- a/ombpdf/webapp/js/main.js
+++ b/ombpdf/webapp/js/main.js
@@ -50,3 +50,34 @@ function setInViewport() {
 ['scroll', 'resize', 'load'].forEach(function(name) {
   window.addEventListener(name, setInViewport);
 });
+
+var tooltip = document.getElementById('tooltip');
+
+function hideTooltip() {
+  tooltip.style.display = 'none';
+}
+
+function showTooltip(charEl, x, y) {
+  var lineEl = charEl.parentNode;
+  var lineno = lineEl.getAttribute('data-lineno');
+  var lineAnno = lineEl.getAttribute('data-anno');
+  var char = charEl.textContent;
+
+  tooltip.style.top = y + 'px';
+  tooltip.style.left = x + 'px';
+  tooltip.style.display = 'block';
+  tooltip.textContent = [
+    `Char ${JSON.stringify(char)} on line #${lineno}`,
+    `Line annotation: ${lineAnno}`,
+  ].join('\n');
+}
+
+onload = function() {
+  document.body.addEventListener('mousemove', function(e) {
+    if (e.target.classList.contains('char')) {
+      showTooltip(e.target, e.pageX + 10, e.pageY + 10);
+    } else {
+      hideTooltip();
+    }
+  });
+};

--- a/ombpdf/webapp/js/main.js
+++ b/ombpdf/webapp/js/main.js
@@ -1,8 +1,10 @@
 var pdfjsLib = require('pdfjs-dist');
 
+// TODO: Get this from the current page's DOM.
 var pdfPath = '/raw/2016/m_16_19_1.pdf';
 
 // Setting worker path to worker bundle.
+// TODO: Get this from the current page's DOM.
 pdfjsLib.PDFJS.workerSrc = '/static/js/pdf.worker.bundle.js';
 
 // Loading a document.
@@ -13,6 +15,7 @@ loadingTask.promise.then(function (pdfDocument) {
   var canvas = document.createElement('canvas');
   firstPage.prepend(canvas);
 
+  // TODO: Do this for all pages.
   return pdfDocument.getPage(1).then(function (pdfPage) {
     // Display page on the existing canvas with 100% scale.
     var viewport = pdfPage.getViewport(1.0);

--- a/ombpdf/webapp/js/main.js
+++ b/ombpdf/webapp/js/main.js
@@ -1,0 +1,30 @@
+var pdfjsLib = require('pdfjs-dist');
+
+var pdfPath = '/raw/2016/m_16_19_1.pdf';
+
+// Setting worker path to worker bundle.
+pdfjsLib.PDFJS.workerSrc = '/static/js/pdf.worker.bundle.js';
+
+// Loading a document.
+var loadingTask = pdfjsLib.getDocument(pdfPath);
+loadingTask.promise.then(function (pdfDocument) {
+  // Request a first page
+  var firstPage = document.querySelector('.page');
+  var canvas = document.createElement('canvas');
+  firstPage.prepend(canvas);
+
+  return pdfDocument.getPage(1).then(function (pdfPage) {
+    // Display page on the existing canvas with 100% scale.
+    var viewport = pdfPage.getViewport(1.0);
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+    var ctx = canvas.getContext('2d');
+    var renderTask = pdfPage.render({
+      canvasContext: ctx,
+      viewport: viewport
+    });
+    return renderTask.promise;
+  });
+}).catch(function (reason) {
+  console.error('Error: ' + reason);
+});

--- a/ombpdf/webapp/js/main.js
+++ b/ombpdf/webapp/js/main.js
@@ -1,32 +1,28 @@
 var pdfjsLib = require('pdfjs-dist');
 
-// TODO: Get this from the current page's DOM.
-var pdfPath = '/raw/2016/m_16_19_1.pdf';
-
 // Setting worker path to worker bundle.
-// TODO: Get this from the current page's DOM.
-pdfjsLib.PDFJS.workerSrc = '/static/js/pdf.worker.bundle.js';
+pdfjsLib.PDFJS.workerSrc = SCRIPT_PARAMS.workerSrc;
 
 // Loading a document.
-var loadingTask = pdfjsLib.getDocument(pdfPath);
-loadingTask.promise.then(function (pdfDocument) {
-  // Request a first page
-  var firstPage = document.querySelector('.page');
-  var canvas = document.createElement('canvas');
-  firstPage.prepend(canvas);
+var loadingTask = pdfjsLib.getDocument(SCRIPT_PARAMS.pdfPath);
 
-  // TODO: Do this for all pages.
-  return pdfDocument.getPage(1).then(function (pdfPage) {
-    // Display page on the existing canvas with 100% scale.
-    var viewport = pdfPage.getViewport(1.0);
-    canvas.width = viewport.width;
-    canvas.height = viewport.height;
-    var ctx = canvas.getContext('2d');
-    var renderTask = pdfPage.render({
-      canvasContext: ctx,
-      viewport: viewport
+loadingTask.promise.then(function (pdfDocument) {
+  document.querySelectorAll('.page').forEach(function(page, i) {
+    var canvas = document.createElement('canvas');
+    page.prepend(canvas);
+
+    return pdfDocument.getPage(i + 1).then(function (pdfPage) {
+      // Display page on the existing canvas with 100% scale.
+      var viewport = pdfPage.getViewport(1.0);
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      var ctx = canvas.getContext('2d');
+      var renderTask = pdfPage.render({
+        canvasContext: ctx,
+        viewport: viewport
+      });
+      return renderTask.promise;
     });
-    return renderTask.promise;
   });
 }).catch(function (reason) {
   console.error('Error: ' + reason);

--- a/ombpdf/webapp/js/main.js
+++ b/ombpdf/webapp/js/main.js
@@ -27,3 +27,26 @@ loadingTask.promise.then(function (pdfDocument) {
 }).catch(function (reason) {
   console.error('Error: ' + reason);
 });
+
+var pages = document.querySelectorAll('.page');
+
+function isElPartlyInViewport (el) {
+  var rect = el.getBoundingClientRect();
+
+  return (
+    rect.bottom >= 0 &&
+    rect.right >= 0 &&
+    rect.top <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.left <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+}
+
+function setInViewport() {
+  pages.forEach(function(page, i) {
+    page.classList.toggle('in-viewport', isElPartlyInViewport(page));
+  });
+}
+
+['scroll', 'resize', 'load'].forEach(function(name) {
+  window.addEventListener(name, setInViewport);
+});

--- a/ombpdf/webapp/templates/rawlayout.html
+++ b/ombpdf/webapp/templates/rawlayout.html
@@ -39,4 +39,7 @@ html, body {
   Inspect this page with developer tools to obtain more details.
 </p>
 {{ html }}
+<script>
+window.SCRIPT_PARAMS = {{ script_params|tojson|safe }};
+</script>
 <script src="{{ url_for('static', filename='js/main.bundle.js') }}"></script>

--- a/ombpdf/webapp/templates/rawlayout.html
+++ b/ombpdf/webapp/templates/rawlayout.html
@@ -43,6 +43,10 @@ html, body {
     overflow: hidden;
 }
 
+.page:not(.in-viewport) .line {
+    display: none;
+}
+
 .char {
     background: #ff0000;
     opacity: 0.5;

--- a/ombpdf/webapp/templates/rawlayout.html
+++ b/ombpdf/webapp/templates/rawlayout.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+* {
+    box-sizing: border-box;
+}
+
+canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+html, body {
+    font-family: sans-serif;
+}
+
+.page {
+    border: 1px solid black;
+    position: relative;
+    display: inline-block;
+    overflow: hidden;
+}
+
+.char {
+    background: rgba(0, 255, 0, 0.2);
+    color: lightgray;
+    position: absolute;
+    overflow: hidden;
+    font-size: 0;
+}
+</style>
+<title>Raw layout for {{ doc.filename }}</title>
+<h1>Raw layout for <code>{{ doc.filename }}</code></h1>
+<p>
+  This page is primarily intended to show the bounding boxes of various page elements.
+</p>
+<p>
+  Inspect this page with developer tools to obtain more details.
+</p>
+{{ html }}
+<script src="{{ url_for('static', filename='js/main.bundle.js') }}"></script>

--- a/ombpdf/webapp/templates/rawlayout.html
+++ b/ombpdf/webapp/templates/rawlayout.html
@@ -83,9 +83,21 @@ h2 a:hover {
 .line.line-OMBListItem .char {
     background: yellow;
 }
+
+#tooltip {
+    white-space: pre-wrap;
+    font-family: monospace;
+    position: absolute;
+    width: 30em;
+    padding: 1em;
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    z-index: 100;
+}
 </style>
 <title>Raw layout for {{ doc.filename }}</title>
 <h1>Raw layout for <code>{{ doc.filename }}</code></h1>
+<aside id="tooltip" style="display: none"></aside>
 <p>
   This page is primarily intended to show the bounding boxes of various page
   elements, along with other metadata.

--- a/ombpdf/webapp/templates/rawlayout.html
+++ b/ombpdf/webapp/templates/rawlayout.html
@@ -47,6 +47,15 @@ html, body {
     display: none;
 }
 
+h2 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+h2 a:hover {
+  text-decoration: underline;
+}
+
 .char {
     background: #ff0000;
     opacity: 0.5;

--- a/ombpdf/webapp/templates/rawlayout.html
+++ b/ombpdf/webapp/templates/rawlayout.html
@@ -15,6 +15,27 @@ html, body {
     font-family: sans-serif;
 }
 
+.legend {
+    list-style-type: none;
+    padding: 0;
+}
+
+.legend .line {
+    display: inline-block;
+    position: relative;
+    width: 1em;
+    height: 1em;
+    border: 1px solid black;
+    overflow: hidden;
+}
+
+.legend .char {
+    top: 0;
+    left: 0;
+    width: 30px;
+    height: 30px;
+}
+
 .page {
     border: 1px solid black;
     position: relative;
@@ -23,21 +44,59 @@ html, body {
 }
 
 .char {
-    background: rgba(0, 255, 0, 0.2);
-    color: lightgray;
+    background: #ff0000;
+    opacity: 0.5;
     position: absolute;
     overflow: hidden;
     font-size: 0;
+}
+
+.line.line-OMBHeading .char {
+    background: #0000ff;
+}
+
+.line.line-OMBParagraph .char {
+    background: #00ff00;
+}
+
+.line.line-OMBPageNumber .char {
+    background: gray;
+}
+
+.line.line-OMBFootnote .char {
+    background: orange;
+}
+
+.line.line-OMBListItem .char {
+    background: yellow;
 }
 </style>
 <title>Raw layout for {{ doc.filename }}</title>
 <h1>Raw layout for <code>{{ doc.filename }}</code></h1>
 <p>
-  This page is primarily intended to show the bounding boxes of various page elements.
+  This page is primarily intended to show the bounding boxes of various page
+  elements, along with other metadata.
 </p>
 <p>
   Inspect this page with developer tools to obtain more details.
 </p>
+<h2>Legend</h2>
+<p>
+  Each bounding box is tinted with a color corresponding to the annotation
+  of the line it's on:
+</p>
+<ul class="legend">
+  {% for name, classname in legend %}
+    <li>
+      <span class="line {{ classname }}"><span class="char"></span></span>
+      <code>{{ name }}</code>
+    </li>
+  {% endfor %}
+  <li>
+    <span class="line"><span class="char"></span></span>
+    <code>None</code>
+  </li>
+</ul>
 {{ html }}
 <script>
 window.SCRIPT_PARAMS = {{ script_params|tojson|safe }};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "pdfminer-fun",
+  "version": "1.0.0",
+  "description": "[![CircleCI](https://circleci.com/gh/18F/omb-pdf.svg?style=svg)](https://circleci.com/gh/18F/omb-pdf)",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/toolness/omb-pdfminer-fun.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/toolness/omb-pdfminer-fun/issues"
+  },
+  "homepage": "https://github.com/toolness/omb-pdfminer-fun#readme",
+  "dependencies": {
+    "pdfjs-dist": "^2.0.185",
+    "webpack": "^3.10.0"
+  }
+}

--- a/tests/test_rawlayout.py
+++ b/tests/test_rawlayout.py
@@ -2,7 +2,9 @@ from ombpdf import rawlayout
 
 
 def test_to_html_works(m_16_19_doc):
-    html = rawlayout.to_html(m_16_19_doc)
+    html, ctx = rawlayout.to_html(m_16_19_doc)
 
     assert 'left:' in html
     assert 'width:' in html
+    assert 'legend' in ctx
+    assert ('OMBFootnote', 'line-OMBFootnote') in ctx['legend']

--- a/tests/test_rawlayout.py
+++ b/tests/test_rawlayout.py
@@ -4,6 +4,5 @@ from ombpdf import rawlayout
 def test_to_html_works(m_16_19_doc):
     html = rawlayout.to_html(m_16_19_doc)
 
-    assert 'Raw layout' in html
     assert 'left:' in html
     assert 'width:' in html

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,16 @@
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = {
+  context: __dirname,
+  watch: true,
+  entry: {
+    'main': './ombpdf/webapp/js/main.js',
+    'pdf.worker': 'pdfjs-dist/build/pdf.worker.entry'
+  },
+  output: {
+    path: path.join(__dirname, 'ombpdf/webapp/static/js/'),
+    publicPath: 'static/js/',
+    filename: '[name].bundle.js'
+  }
+};


### PR DESCRIPTION
This PR builds upon #23 by mashes up pdf.js rendering with our pdfminer-derived data to show how our layout inferences correlate with the actual page:

![layout](https://user-images.githubusercontent.com/124687/33621779-ee51e80a-d9b9-11e7-8ccf-ed3202779728.png)

In the above screenshot, everything in green is derived from pdfminer's `LTChar` bounding boxes, while everything in black is drawn by pdf.js.  It seems pdf.js and pdfminer calculate the same layout metrics, which is a relief.

## Additional thoughts

Aside from being useful for debugging, it raises possibilities about eventually integrating this kind of view into the OMB Policy Library's PDF import workflow.

For example, it might be easier for users to "point at the page" to tell us about inference mistakes we've made than it would be for them to revert our changes and implement the correct content using a rich text editing widget. This may be particularly true with tables.

Furthermore, having users point at the mistakes we made gives us valuable data that allows us to improve our algorithm to make fewer mistakes. This is data is much easier to make sense of than e.g. looking at the post-import edits made in a rich text editor. It could also be used as raw training data for supervised machine learning, if we decide to eventually go that route.

The one major downside of this approach is that it's not accessible--since we're assuming that our PDFs aren't tagged with useful accessibility metadata (er, we should validate this assumption actually), the PDFs themselves are by nature inaccessible, so asking the user to compare our inferences with the original PDF will be very hard for visually impaired users.
