### PR TITLE
Heading size detection

### DIFF
--- a/ombpdf/fontsize.py
+++ b/ombpdf/fontsize.py
@@ -58,10 +58,10 @@ class FontSize(namedtuple('FontSize', ['font', 'size'])):
 
     __cache = weakref.WeakKeyDictionary()
 
-    def is_near(self, other):
+    def is_near(self, other, gap=1):
         if self.font != other.font:
             return False
-        return abs(self.size - other.size) <= 1
+        return abs(self.size - other.size) <= float(gap)
 
     @classmethod
     def from_ltchar(cls, ltchar):

--- a/ombpdf/footnotes.py
+++ b/ombpdf/footnotes.py
@@ -19,14 +19,12 @@ NUMBER_RE = re.compile(r'[0-9]')
 FOOTNOTE_RE = re.compile(r'([0-9]+) (.+)')
 
 
-def is_significantly_smaller(size, normal_size, gap=0.2):
-    return float(normal_size - size) > float(gap)
-
 def line_contains_big_chars(line, doc):
     for char in line:
         if char.fontsize.size + Decimal('0.5') >= doc.paragraph_fontsize.size:
             return True
     return False
+
 
 def annotate_citations(doc):
     citations = []
@@ -44,8 +42,9 @@ def annotate_citations(doc):
             citations.append(citation)
 
         for char in line:
-            if is_significantly_smaller(char.fontsize.size,
-                                        doc.paragraph_fontsize.size):
+            if util.is_significantly_smaller(char.fontsize.size,
+                                             doc.paragraph_fontsize.size,
+                                             gap=0.7):
                 if NUMBER_RE.match(str(char)):
                     if prev_paragraph_chars:
                         curr_citation.append(char)

--- a/ombpdf/headings.py
+++ b/ombpdf/headings.py
@@ -1,6 +1,7 @@
 from functools import total_ordering
 
 from .document import OMBHeading
+from .util import is_x_smaller_than_y
 
 
 @total_ordering
@@ -13,6 +14,8 @@ class Style:
     which is a higher "heading level" than the other, e.g. <H1> vs. <H2>,
     hence the ordering.
     """
+
+    COMPARISON_GAP = 0.2
 
     def __init__(self, is_underlined, fontsize):
         self.is_underlined = is_underlined
@@ -34,12 +37,17 @@ class Style:
 
     def __eq__(self, other):
         return (self.is_underlined == other.is_underlined and
-                self.fontsize == other.fontsize)
+                self.fontsize.is_near(other.fontsize,
+                                      gap=self.COMPARISON_GAP))
 
     def __lt__(self, other):
-        if self.fontsize.size < other.fontsize.size:
+        if is_x_smaller_than_y(self.fontsize.size,
+                               other.fontsize.size,
+                               gap=self.COMPARISON_GAP):
             return True
-        if self.fontsize.size > other.fontsize.size:
+        if is_x_smaller_than_y(other.fontsize.size,
+                               self.fontsize.size,
+                               gap=self.COMPARISON_GAP):
             return False
         # The fonts are the same size, so compare them by complexity.
         return self.complexity_score() < other.complexity_score()
@@ -56,7 +64,8 @@ class Style:
 def get_heading_line_style(line):
     style = None
     for char, text in line.iter_char_chunks():
-        if not text.strip(): continue
+        if not text.strip():
+            continue
         if style is not None:
             # This line has multiple styles, so we'll assume
             # (possibly incorrectly) that it can't be a heading.

--- a/ombpdf/util.py
+++ b/ombpdf/util.py
@@ -27,3 +27,11 @@ def iter_flattened_layout(items, class_filter=object):
             stack.extend(children)
         if isinstance(item, class_filter):
             yield item
+
+
+def is_significantly_smaller(size, normal_size, gap=0.2):
+    return float(normal_size - size) > float(gap)
+
+
+def is_x_smaller_than_y(x, y, gap=0.2):
+    return float(y - x) > float(gap)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,16 @@ def m_16_19_doc(m_16_19_pages):
 
 
 @pytest.fixture
+def m_15_16_pages():
+    return read_pages('2015/m-15-16.pdf')
+
+
+@pytest.fixture
+def m_15_16_doc(m_15_16_pages):
+    return document.OMBDocument(m_15_16_pages, filename='m-15-16.pdf')
+
+
+@pytest.fixture
 def m_15_17_pages():
     return read_pages('2015/m-15-17.pdf')
 

--- a/tests/test_headings.py
+++ b/tests/test_headings.py
@@ -41,3 +41,31 @@ def test_annotate_headings_works(m_16_19_doc):
 
 def test_main_works(m_16_19_doc):
     headings.main(m_16_19_doc)
+
+
+def test_annotate_headings_m_15_16(m_15_16_doc):
+    """
+    Minor difference in font size were causing many false positives for
+    headings in this document; this test checks that only the actual headings
+    are present.
+    We're looking only at what's after the SUBJECT: line because that line is
+    part of the metadata and should be treated differently.
+    """
+    split_heading = "SUBJECT: Multi-Agency Science and Technology Priorities "\
+        "for the FY 2017 Budget"
+    headers = [str(line).strip() for line in
+               headings.annotate_headings(m_15_16_doc)]
+    if split_heading in headers:
+        subj_index = headers.index(split_heading)
+        relevant = headers[subj_index + 1:]
+    else:
+        relevant = headers
+
+    expected = [
+        "Multi-Agency R&D priorities",
+        "R&D Infrastructure",
+        "Other R&D Program Guidance",
+        "STEM Education Guidance",
+    ]
+
+    assert relevant == expected


### PR DESCRIPTION
Not everything
Should be placed above the rest.
Standouts should stand out.

Adds fuzziness to the comparisons used to determine whether or not something is a heading.