### PR TITLE
Realign lines past left edge instead of culling them

### DIFF
--- a/ombpdf/document.py
+++ b/ombpdf/document.py
@@ -31,13 +31,13 @@ class OMBDocument:
         self.left_edge = self._calc_left_edge()
         self.annotators = AnnotatorTracker(self)
 
-        self._cull_lines_left_of_left_edge()
+        self._realign_lines_left_of_left_edge()
 
-    def _cull_lines_left_of_left_edge(self):
+    def _realign_lines_left_of_left_edge(self):
         for page in self.pages:
             lines = [line for line in page if line.left_edge < self.left_edge]
             for line in lines:
-                page.remove(line)
+                line.left_edge = self.left_edge
 
     def _calc_left_edge(self):
         counter = Counter()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,16 @@ def read_pages(relpath):
 
 
 @pytest.fixture
+def m_11_29_pages():
+    return read_pages('2011/m11-29.pdf')
+
+
+@pytest.fixture
+def m_11_29_doc(m_11_29_pages):
+    return document.OMBDocument(m_11_29_pages, filename='m11-29.pdf')
+
+
+@pytest.fixture
 def m_16_19_pages():
     return read_pages('2016/m_16_19_1.pdf')
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -11,3 +11,9 @@ def test_textline_is_blank_works(m_16_19_doc):
 def test_page_numbers_work(m_16_19_doc):
     assert m_16_19_doc.pages[0].number == 1
     assert m_16_19_doc.pages[1].number == 2
+
+
+def test_useful_lines_are_not_culled(m_11_29_doc):
+    lastpage_text = '\n'.join([str(line) for line in m_11_29_doc.pages[-1]])
+
+    assert 'opportunities to reduce duplication' in lastpage_text


### PR DESCRIPTION
This fixes #29, but in a kind of weird way.  Basically, instead of outright _removing_ lines that start past the left edge of the page, we hack them so the rest of our layout algorithms _think_ they're flush with the left edge of the page.

I guess another alternative is to just remove the hack and fix all our logic that compares things to the left edge to test for "less than or equal to the left edge" instead of equality/fuzzy equality.