### PR TITLE
Add eqnamedtuple class and make annotations use it.

### DIFF
--- a/ombpdf/document.py
+++ b/ombpdf/document.py
@@ -1,4 +1,4 @@
-from collections import namedtuple, Counter
+from collections import Counter
 from decimal import Decimal
 import logging
 import math
@@ -8,6 +8,7 @@ from pdfminer import layout
 from . import fontsize
 from . import util
 from .annotators import AnnotatorTracker
+from .eqnamedtuple import eqnamedtuple
 
 
 logger = logging.getLogger(__name__)
@@ -74,21 +75,21 @@ class OMBPage(list):
         self.number = number
 
 
-OMBFootnoteCitation = namedtuple('OMBFootnoteCitation', ['number',
-                                                         'preceding_text'])
+OMBFootnoteCitation = eqnamedtuple('OMBFootnoteCitation', ['number',
+                                                           'preceding_text'])
 
-OMBFootnote = namedtuple('OMBFootnote', ['number', 'text'])
+OMBFootnote = eqnamedtuple('OMBFootnote', ['number', 'text'])
 
-OMBPageNumber = namedtuple('OMBPageNumber', ['number'])
+OMBPageNumber = eqnamedtuple('OMBPageNumber', ['number'])
 
-OMBParagraph = namedtuple('OMBParagraph', ['id'])
+OMBParagraph = eqnamedtuple('OMBParagraph', ['id'])
 
-OMBListItem = namedtuple('OMBListItem', ['list_id', 'number', 'is_ordered',
-                                         'indentation'])
+OMBListItem = eqnamedtuple('OMBListItem', ['list_id', 'number', 'is_ordered',
+                                           'indentation'])
 
-OMBListItemMarker = namedtuple('OMBListItemMarker', ['is_ordered'])
+OMBListItemMarker = eqnamedtuple('OMBListItemMarker', ['is_ordered'])
 
-OMBHeading = namedtuple('OMBHeading', ['level'])
+OMBHeading = eqnamedtuple('OMBHeading', ['level'])
 
 
 class AnnotatableMixin:

--- a/ombpdf/eqnamedtuple.py
+++ b/ombpdf/eqnamedtuple.py
@@ -1,0 +1,45 @@
+from collections import namedtuple
+
+
+def eqnamedtuple(typename, field_names):
+    '''
+    Factory function for creating a namedtuple subclass that
+    features stricter equality, in that for the '==' operator
+    to work, each operand must also have the exact same
+    class.
+
+    For instance, normal namedtuples are equal even if they
+    are of different classes, so long as the tuple elements
+    themselves are equal:
+
+        >>> Foo = namedtuple('Foo', ['foo'])
+        >>> Bar = namedtuple('Bar', ['bar'])
+        >>> Foo(1) == Bar(1)
+        True
+
+    However, with eqnamedtuple(), this won't work:
+
+        >>> Foo = eqnamedtuple('Foo', ['foo'])
+        >>> Bar = eqnamedtuple('Bar', ['bar'])
+        >>> Foo(1) == Bar(1)
+        False
+
+    Instead, the tuple subclasses themselves must match exactly:
+
+        >>> Foo(1) == Foo(1)
+        True
+    '''
+
+    class Result(namedtuple(typename, field_names)):
+        __slots__ = ()
+
+        def __eq__(self, other):
+            return (other and other.__class__ == self.__class__
+                    and tuple(self) == tuple(other))
+
+        def __ne__(self, other):
+            return not self.__eq__(other)
+
+    Result.__name__ = typename
+
+    return Result

--- a/ombpdf/semhtml.py
+++ b/ombpdf/semhtml.py
@@ -41,8 +41,7 @@ def to_html(doc):
             return False
         curr_tagname, curr_anno = block_stack[-1]
         if anno is not None:
-            return (anno.__class__ == curr_anno.__class__ and
-                    anno == curr_anno)
+            return anno == curr_anno
         return curr_tagname in tagnames
 
     def close_all_blocks():

--- a/tests/test_eqnamedtuple.py
+++ b/tests/test_eqnamedtuple.py
@@ -1,0 +1,16 @@
+from ombpdf.eqnamedtuple import eqnamedtuple
+
+
+def test_name_works():
+    Blah = eqnamedtuple('Blah', ['u'])
+
+    assert Blah.__name__ == 'Blah'
+
+
+def test_eq_works():
+    Foo = eqnamedtuple('Foo', ['foo'])
+    Bar = eqnamedtuple('Bar', ['bar'])
+
+    assert Foo(1) != Bar(1)
+    assert Foo(1) == Foo(1)
+    assert Bar('a') == Bar('a')

--- a/tests/test_footnotes.py
+++ b/tests/test_footnotes.py
@@ -1,8 +1,12 @@
 from ombpdf import footnotes, lists, pagenumbers
 
 
+def tuplify(iterable):
+    return [tuple(x) for x in iterable]
+
+
 def test_annotate_citations_works(m_16_19_doc):
-    citations = footnotes.annotate_citations(m_16_19_doc)
+    citations = tuplify(footnotes.annotate_citations(m_16_19_doc))
     assert citations[:3] == [
         (1, 'shift IT investments to more efficient computing '
             'platforms and technologies.'),
@@ -14,7 +18,7 @@ def test_annotate_citations_works(m_16_19_doc):
 def test_annotate_footnotes_works(m_16_19_doc):
     # Page numbers and footnotes can clash; handle page numbers first.
     pagenumbers.annotate_page_numbers(m_16_19_doc)
-    notes = footnotes.annotate_footnotes(m_16_19_doc)
+    notes = tuplify(footnotes.annotate_footnotes(m_16_19_doc))
     assert notes[:1] == [
         (1, 'The FDCCI was first established by OMB “Memo for CIOs: '
             'Federal Data Center Consolidation Initiative,” issued '
@@ -33,7 +37,7 @@ def test_main_15_17(m_15_17_doc):
 def test_annotate_footnotes_m_15_17(m_15_17_doc):
     # Page numbers and footnotes can clash; handle page numbers first.
     pagenumbers.annotate_page_numbers(m_15_17_doc)
-    notes = footnotes.annotate_footnotes(m_15_17_doc)
+    notes = tuplify(footnotes.annotate_footnotes(m_15_17_doc))
     # Run this to check that there isn't a clash over lists:
     lists.annotate_lists(m_15_17_doc)
 
@@ -59,8 +63,8 @@ def test_annotate_footnotes_m_15_17(m_15_17_doc):
 def test_annotate_footnotes_m_17_11_0(m_17_11_0_doc):
     # Page numbers and footnotes can clash; handle page numbers first.
     pagenumbers.annotate_page_numbers(m_17_11_0_doc)
-    notes = footnotes.annotate_footnotes(m_17_11_0_doc)
-    citations = footnotes.annotate_citations(m_17_11_0_doc)
+    notes = tuplify(footnotes.annotate_footnotes(m_17_11_0_doc))
+    citations = tuplify(footnotes.annotate_citations(m_17_11_0_doc))
     # Run this to check that there isn't a clash over lists:
     lists.annotate_lists(m_17_11_0_doc)
 


### PR DESCRIPTION
I wrote some of the original code for this tool assuming that `namedtuple` instances were only equal if they not only shared the same underlying data, but also had the same class.  However, I later found that this wasn't the case, as e.g. `OMBParagraph(1) == OMBPageNumber(1)`.

This adds an `eqnamedtuple` factory function that creates a `namedtuple` subclass that overrides the `==` and `!=` operators to behave the way I'd originally assumed they did, which will simplify implementation going forward.
