### PR TITLE
Add an xfail test case for page numbering

### DIFF
--- a/ombpdf/rawlayout.py
+++ b/ombpdf/rawlayout.py
@@ -28,7 +28,8 @@ def to_html(doc):
             f'<h2 id="{page.number}">'
             f'<a href="#{page.number}">Page {page.number}</a></h2>'
         )
-        chunks.append(f'<div class="page" {pagestyle}>\n')
+        chunks.append(f'<div class="page" data-page="{page.number}" '
+                      f'{pagestyle}>\n')
         for line, lineno in zip(page, range(1, len(page) + 1)):
             line_classes = ['line']
             if line.annotation is not None:

--- a/ombpdf/webapp/js/bbox.js
+++ b/ombpdf/webapp/js/bbox.js
@@ -1,0 +1,154 @@
+class Bbox {
+  constructor(page, x0, y0, x1, y1) {
+    this.page = page;
+    this.x0 = x0;
+    this.y0 = y0;
+    this.x1 = x1;
+    this.y1 = y1;
+  }
+
+  toCss() {
+    return [
+      `bottom: ${this.y0 - 1}px`,
+      `left: ${this.x0}px`,
+      `width: ${this.x1 - this.x0}px`,
+      `height: ${this.y1 - this.y0}px`
+    ].join('; ')
+  }
+
+  toQuerystring() {
+    return `?bbox=${this.page},${this.x0},${this.y0},${this.x1},${this.y1}`;
+  }
+
+  static fromQuerystring(text) {
+    const match = text.match(/bbox=([0-9,.]+)/);
+
+    if (!match) {
+      return null;
+    }
+
+    const numbers = match[1].split(',');
+
+    if (numbers.length !== 5) {
+      return null;
+    }
+
+    return new Bbox(parseInt(numbers[0]),
+                    parseFloat(numbers[1]),
+                    parseFloat(numbers[2]),
+                    parseFloat(numbers[3]),
+                    parseFloat(numbers[4]));
+  }
+}
+
+function showBbox(bbox) {
+  const pageEl = document.querySelector(`.page[data-page="${bbox.page}"]`);
+  const bboxEl = document.createElement('div');
+
+  pageEl.appendChild(bboxEl);
+
+  bboxEl.classList.add('bbox');
+  bboxEl.setAttribute('style', bbox.toCss());
+
+  return bboxEl;
+}
+
+let currBboxEl = null;
+
+function setCurrBbox(bbox) {
+  if (currBboxEl !== null) {
+    currBboxEl.parentNode.removeChild(currBboxEl);
+    currBboxEl = null;
+  }
+  if (bbox !== null) {
+    currBboxEl = showBbox(bbox);
+  }
+}
+
+function dragInfoToBbox(dragInfo) {
+  if (dragInfo.startX === dragInfo.currX ||
+      dragInfo.startY === dragInfo.currY) {
+    return null;
+  }
+
+  const canvasRect = dragInfo.pageCanvas.getBoundingClientRect();
+  const canvasLeft = canvasRect.left + window.scrollX;
+  const canvasTop = canvasRect.top + window.scrollY;
+  const pageHeight = dragInfo.pageCanvas.height;
+  let x0 = dragInfo.startX - canvasLeft;
+  let y0 = pageHeight - (dragInfo.startY - canvasTop);
+  let x1 = dragInfo.currX - canvasLeft;
+  let y1 = pageHeight - (dragInfo.currY - canvasTop);
+
+  if (x0 > x1) {
+    const temp = x0;
+    x0 = x1;
+    x1 = temp;
+  }
+
+  if (y0 > y1) {
+    const temp = y0;
+    y0 = y1;
+    y1 = temp;
+  }
+
+  return new Bbox(dragInfo.page, x0, y0, x1, y1);
+}
+
+let currDragInfo = null;
+
+window.addEventListener('mousedown', e => {
+  if (e.target instanceof HTMLCanvasElement) {
+    const pageEl = e.target.parentNode;
+
+    currDragInfo = {
+      page: parseInt(pageEl.getAttribute('data-page')),
+      pageCanvas: e.target,
+      startX: e.pageX,
+      startY: e.pageY,
+      currX: e.pageX,
+      currY: e.pageY,
+    };
+
+    setCurrBbox(dragInfoToBbox(currDragInfo));
+    e.preventDefault();
+  }
+});
+
+window.addEventListener('mousemove', e => {
+  if (currDragInfo === null) return;
+
+  currDragInfo.currX = e.pageX;
+  currDragInfo.currY = e.pageY;
+
+  setCurrBbox(dragInfoToBbox(currDragInfo));
+  e.preventDefault();
+});
+
+window.addEventListener('mouseup', e => {
+  if (currDragInfo === null) return;
+
+  let bbox = dragInfoToBbox(currDragInfo);
+
+  setCurrBbox(bbox);
+
+  currDragInfo = null;
+  e.preventDefault();
+
+  const currUrl = window.location.pathname + window.location.search +
+                  window.location.hash;
+
+  const url = window.location.pathname + (bbox ? bbox.toQuerystring() : '') +
+              window.location.hash;
+
+  if (currUrl !== url) {
+    window.history.pushState(null, '', url);
+  }
+});
+
+function setCurrBboxFromQuerystring() {
+  setCurrBbox(Bbox.fromQuerystring(window.location.search));
+}
+
+window.addEventListener('load', setCurrBboxFromQuerystring);
+window.addEventListener('popstate', setCurrBboxFromQuerystring);

--- a/ombpdf/webapp/js/main.js
+++ b/ombpdf/webapp/js/main.js
@@ -1,3 +1,4 @@
 require('./render-pdf');
 require('./in-viewport');
 require('./tooltip');
+require('./bbox');

--- a/ombpdf/webapp/templates/rawlayout.html
+++ b/ombpdf/webapp/templates/rawlayout.html
@@ -94,6 +94,12 @@ h2 a:hover {
     color: white;
     z-index: 100;
 }
+
+.bbox {
+    position: absolute;
+    border: 1px solid blue;
+    pointer-events: none;
+}
 </style>
 <title>Raw layout for {{ doc.filename }}</title>
 <h1>Raw layout for <code>{{ doc.filename }}</code></h1>

--- a/tests/bbox.py
+++ b/tests/bbox.py
@@ -1,0 +1,68 @@
+import re
+from collections import namedtuple
+
+from .conftest import load_document
+
+
+BboxInfo = namedtuple('BboxInfo', [
+    'pdf',
+    'page',
+    'x0',
+    'y0',
+    'x1',
+    'y1',
+])
+
+RAWLAYOUT_URL_RE = re.compile(r'^.+\/rawlayout\/(.*)\?bbox=([0-9.,]+).*$')
+
+def parse_rawlayout_url(url):
+    '''
+    >>> parse_rawlayout_url('http://localhost:5000/rawlayout/2016/m_16_19_1.pdf?bbox=4,515,16.9375,559,93.9375#4')
+    BboxInfo(pdf='2016/m_16_19_1.pdf', page=4, x0=515.0, y0=16.9375, x1=559.0, y1=93.9375)
+
+    >>> parse_rawlayout_url('blah')
+    Traceback (most recent call last):
+    ...
+    ValueError: 'blah' is not a valid rawlayout URL
+    '''
+
+    match = RAWLAYOUT_URL_RE.match(url)
+
+    if not match:
+        raise ValueError(f"'{url}' is not a valid rawlayout URL")
+
+    pdf = match.group(1)
+    numbers = match.group(2).split(',')
+    page = int(numbers[0])
+    x0 = float(numbers[1])
+    y0 = float(numbers[2])
+    x1 = float(numbers[3])
+    y1 = float(numbers[4])
+
+    return BboxInfo(pdf, page, x0, y0, x1, y1)
+
+
+def find_line(url):
+    info = parse_rawlayout_url(url)
+    doc = load_document(info.pdf)
+    page = doc.pages[info.page - 1]
+    lines = lines_in_bbox(page, info.x0, info.y0, info.x1, info.y1)
+
+    assert len(lines) == 1
+
+    return (doc, page, lines[0])
+
+
+def lines_in_bbox(page, x0, y0, x1, y1):
+    '''
+    Returns a list of all lines on the page that are fully contained in the
+    given bounding box.
+    '''
+
+    return [
+        line for line in page
+        if (line.lttextline.x0 >= x0 and
+            line.lttextline.y0 >= y0 and
+            line.lttextline.x1 <= x1 and
+            line.lttextline.y1 <= y1)
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,11 @@ def read_pages(relpath):
     return pages_cache[relpath]
 
 
+def load_document(path):
+    ltpages = read_pages(path)
+    return document.OMBDocument(ltpages, filename=path)
+
+
 @pytest.fixture
 def m_11_29_pages():
     return read_pages('2011/m11-29.pdf')

--- a/tests/test_pagenumbers.py
+++ b/tests/test_pagenumbers.py
@@ -1,4 +1,7 @@
+import pytest
+
 from ombpdf import pagenumbers
+from . import bbox
 
 
 def test_annotate_page_numbers_works(m_16_19_doc):
@@ -7,6 +10,15 @@ def test_annotate_page_numbers_works(m_16_19_doc):
         for line in pagenumbers.annotate_page_numbers(m_16_19_doc)
     ]
     assert lines == ['1', '2', '3', '5', '6', '7', '8', '10', '11']
+
+
+@pytest.mark.xfail(raises=AssertionError,
+                   reason="https://github.com/18F/omb-pdf/issues/1")
+def test_page_numbers_with_weird_line_ordering_are_recognized():
+    doc, _, line = bbox.find_line('http://localhost:5000/rawlayout/2016/m_16_19_1.pdf?bbox=4,515,16.9375,559,93.9375#4')
+
+    doc.annotators.require('page_numbers')
+    assert line.annotation == pagenumbers.OMBPageNumber(4)
 
 
 def test_main_works(m_16_19_doc):


### PR DESCRIPTION
Concretely, this adds an [`xfail`](https://docs.pytest.org/en/latest/skipping.html#xfail-mark-test-functions-as-expected-to-fail) test for #1.

However, it also adds some scaffolding to make it easier to generate test cases based on the visual position of elements on a page.

Basically, the rawlayout view of the dev server now allows you to click-and-drag blue bounding boxes on pages:

> ![bbox](https://user-images.githubusercontent.com/124687/33783597-68ecb914-dc2b-11e7-87a9-97b3d1488256.png)

Every time you finish creating a bounding box, the URL changes to reflect it; the URL can be revisited at any time to see the bounding box.

These URLs can be used from test cases to assert things based on the content within the bounding box. In this PR, for instance, we have the following test, which uses the above bounding box:

```python
@pytest.mark.xfail(raises=AssertionError,
                   reason="https://github.com/18F/omb-pdf/issues/1")
def test_page_numbers_with_weird_line_ordering_are_recognized():
    doc, _, line = bbox.find_line('http://localhost:5000/rawlayout/2016/m_16_19_1.pdf?bbox=4,515,16.9375,559,93.9375#4')

    doc.annotators.require('page_numbers')
    assert line.annotation == pagenumbers.OMBPageNumber(4)
```

The use of the URL in the test case is admittedly a bit odd.  The reason I wanted the whole URL in there was so it'd be easy for developers to just copy-and-paste it into their browser to see what it was visually referring to.  However, the actual `bbox.find_line()` function the URL is passed-to never actually visits the URL; it just parses its details, such as the PDF file to load and the coordinates of the bounding box, and then loads the PDF and filters its lines. I could have just as easily made `find_line()` a normal function that took those arguments, instead of a URL, but that would have made it harder for developers to go the other way and visually see the bounding box in the dev server.

Anyways, it's just an idea I guess. I was hoping it could make it easier for us to generate test cases going forward.
