### PR TITLE
Add horizlines.py, use it for footnote detection

### DIFF
--- a/ombpdf/fontsize.py
+++ b/ombpdf/fontsize.py
@@ -61,7 +61,7 @@ class FontSize(namedtuple('FontSize', ['font', 'size'])):
     def is_near(self, other, gap=1):
         if self.font != other.font:
             return False
-        return abs(self.size - other.size) <= float(gap)
+        return util.is_near(self.size, other.size, gap=gap)
 
     @classmethod
     def from_ltchar(cls, ltchar):

--- a/ombpdf/horizlines.py
+++ b/ombpdf/horizlines.py
@@ -1,0 +1,26 @@
+from collections import namedtuple
+
+from pdfminer import layout
+
+from . import util
+
+
+HorizontalLine = namedtuple('HorizontalLine', ['y', 'start', 'end'])
+
+# Maximum height of a horizontal line (in points, I think).
+MAX_LINE_HEIGHT = 4.0
+
+def get_horizontal_lines(page):
+    hlines = []
+    for rect in util.iter_flattened_layout(page.ltpage, layout.LTRect):
+        x0, y0 = rect.pts[0]
+        x1, y1 = rect.pts[2]
+        height = y1 - y0
+        if y1 - y0 < MAX_LINE_HEIGHT:
+            hlines.append(HorizontalLine((y0 + y1) / 2, x0, x1))
+    for line in util.iter_flattened_layout(page.ltpage, layout.LTLine):
+        x0, y0 = line.pts[0]
+        x1, y1 = line.pts[1]
+        if util.is_near(y0, y1) and line.linewidth <= MAX_LINE_HEIGHT:
+            hlines.append(HorizontalLine(y0, x0, x1))
+    return hlines

--- a/ombpdf/underlines.py
+++ b/ombpdf/underlines.py
@@ -1,14 +1,5 @@
-from collections import namedtuple
+from .horizlines import get_horizontal_lines
 
-from pdfminer import layout
-
-from . import util
-
-
-HorizontalLine = namedtuple('HorizontalLine', ['y', 'start', 'end'])
-
-# Maximum height of an underline (in points, I think).
-MAX_LINE_HEIGHT = 4.0
 
 # Percentage of bbox height underline can be from bottom of a line's bbox.
 MAX_LINE_BBOX_DIST = 0.25
@@ -27,13 +18,7 @@ def set_underlines(doc):
 
 def set_underlines_in_page(page):
     underlines = []
-    hlines = []
-    for rect in util.iter_flattened_layout(page.ltpage, layout.LTRect):
-        x0, y0 = rect.pts[0]
-        x1, y1 = rect.pts[2]
-        height = y1 - y0
-        if y1 - y0 < MAX_LINE_HEIGHT:
-            hlines.append(HorizontalLine((y0 + y1) / 2, x0, x1))
+    hlines = get_horizontal_lines(page)
     for line in page:
         for hline in hlines:
             tl = line.lttextline

--- a/ombpdf/util.py
+++ b/ombpdf/util.py
@@ -35,3 +35,7 @@ def is_significantly_smaller(size, normal_size, gap=0.2):
 
 def is_x_smaller_than_y(x, y, gap=0.2):
     return float(y - x) > float(gap)
+
+
+def is_near(a, b, gap=1):
+    return abs(a - b) <= float(gap)

--- a/tests/test_html.snapshot.html
+++ b/tests/test_html.snapshot.html
@@ -385,13 +385,13 @@ html {
 </span></div><div ><span style="font-size: 16.6pt" class="underline bold">Target Value</span><span style="font-size: 16.2pt" class="underline"> 
 </span></div><div ><span style="font-size: 10.7pt" class="italic">Total GFA of Energy Metered 
 </span></div><div ><span style="font-size: 10.7pt" class="underline italic">Data Centers</span><span style="font-size: 10.8pt" class="underline"> 
-</span></div><div title="Footnote 23" class="footnote"><span style="font-size: 10.7pt" class="italic">Total GFA of All Tiered Data 
-</span></div><div title="Footnote 23" class="footnote"><span style="font-size: 10.7pt" class="italic">Centers 
-</span></div><div title="Footnote 23" class="footnote"><span style="font-size: 0.6pt" class="italic"> 
-</span></div><div title="Footnote 23" class="footnote"><span style="font-size: 10.7pt" class="underline italic">Total Energy Used</span><span style="font-size: 10.8pt" class="underline"> 
-</span></div><div title="Footnote 23" class="footnote"><span style="font-size: 10.7pt" class="italic">Total IT Equipment Energy 
-</span></div><div title="Footnote 23" class="footnote"><span style="font-size: 10.7pt" class="italic">Used 
-</span></div><div title="Footnote 23" class="footnote"><span style="font-size: 0.6pt"> 
+</span></div><div ><span style="font-size: 10.7pt" class="italic">Total GFA of All Tiered Data 
+</span></div><div ><span style="font-size: 10.7pt" class="italic">Centers 
+</span></div><div ><span style="font-size: 0.6pt" class="italic"> 
+</span></div><div ><span style="font-size: 10.7pt" class="underline italic">Total Energy Used</span><span style="font-size: 10.8pt" class="underline"> 
+</span></div><div ><span style="font-size: 10.7pt" class="italic">Total IT Equipment Energy 
+</span></div><div ><span style="font-size: 10.7pt" class="italic">Used 
+</span></div><div ><span style="font-size: 0.6pt"> 
 </span></div><div ><span style="font-size: 16.2pt">100% 
 </span></div><div ><span style="font-size: 16.2pt" class="underline">≤</span><span style="font-size: 16.2pt"> 1.5 (≤ 1.4 for 
 </span></div><div ><span style="font-size: 16.2pt">new data 

--- a/tests/test_semhtml.snapshot.html
+++ b/tests/test_semhtml.snapshot.html
@@ -312,6 +312,13 @@ FYE 2018
 Target Value 
 Total GFA of Energy Metered 
 Data Centers 
+Total GFA of All Tiered Data 
+Centers 
+ 
+Total Energy Used 
+Total IT Equipment Energy 
+Used 
+ 
 100% 
 ≤ 1.5 (≤ 1.4 for 
 new data 
@@ -623,7 +630,7 @@ become available.
 <dt id="footnote-22">22</dt>
 <dd>This can be PUE for the facility as a whole in cases where the agency only contracts for a portion of a larger facility; however, if PUE metrics are available specific to the agency’s use, that is preferred.  <a href="#footnote-citation-22">Back to citation</a></dd>
 <dt id="footnote-23">23</dt>
-<dd>For non-tiered data centers, only automated monitoring of server utilization is required. Total GFA of All Tiered Data Centers  Total Energy Used Total IT Equipment Energy Used   <a href="#footnote-citation-23">Back to citation</a></dd>
+<dd>For non-tiered data centers, only automated monitoring of server utilization is required.  <a href="#footnote-citation-23">Back to citation</a></dd>
 <dt id="footnote-24">24</dt>
 <dd>While agencies should strive to achieve each applicable optimization target for each data center, only PUE targets will be calculated on a per-data center basis. All other targets will be calculated at the agency inventory-level.  <a href="#footnote-citation-24">Back to citation</a></dd>
 <dt id="footnote-25">25</dt>


### PR DESCRIPTION
This is a PR against #36 which enhances footnote detection to only detect continued footnotes if there's a horizontal line above the first line of the continued footnote.

It also likely improves the detection of underlines, though I don't have actual evidence for that.
